### PR TITLE
Add material configuration panel with texture management

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,8 +69,12 @@
                 </div>
                 <div class="material-color-picker" data-color-picker>
                   <label class="material-field">
-                    <span class="material-field__label">Базовый цвет</span>
-                    <input type="color" class="material-field__input" data-color-input />
+                    <input
+                      type="color"
+                      class="material-field__input"
+                      data-color-input
+                      aria-label="Base color"
+                    />
                   </label>
                 </div>
                 <div class="material-texture-picker is-hidden" data-color-texture>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ru">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -51,11 +51,24 @@
       </div>
       <aside class="panel panel--right" data-material-panel>
         <div class="material-panel">
-          <p class="material-panel__title">Материал</p>
-          <p class="material-panel__message" data-material-message>Выберите один меш для настройки материала.</p>
+          <p class="material-panel__title">Material</p>
+          <p class="material-panel__message" data-material-message>Select a single mesh to edit its material.</p>
           <div class="material-panel__body is-hidden" data-material-body>
             <details class="material-section" open>
-              <summary class="material-section__summary">Цвет</summary>
+              <summary class="material-section__summary">
+                <span class="material-section__label">
+                  <span>Color</span>
+                  <button
+                    type="button"
+                    class="material-section__help-button"
+                    aria-label="The Color section lets you apply either a solid base color or a texture map. Only the selected option affects the mesh."
+                    data-section-help
+                    data-tooltip="Choose between a solid base color or a texture map. Only the selected option affects the mesh."
+                  >
+                    ?
+                  </button>
+                </span>
+              </summary>
               <div class="material-section__content">
                 <div class="material-mode" role="radiogroup">
                   <label class="material-mode__option">
@@ -84,7 +97,7 @@
                     <img
                       class="texture-upload__image"
                       data-color-texture-image
-                      alt="Предпросмотр текстуры цвета"
+                      alt="Color texture preview"
                       width="100"
                       height="100"
                     />
@@ -92,7 +105,7 @@
                       type="button"
                       class="texture-upload__remove"
                       data-color-texture-remove
-                      aria-label="Удалить текстуру"
+                      aria-label="Remove color texture"
                     >
                       ×
                     </button>
@@ -103,7 +116,20 @@
               </div>
             </details>
             <details class="material-section" open>
-              <summary class="material-section__summary">Opacity</summary>
+              <summary class="material-section__summary">
+                <span class="material-section__label">
+                  <span>Opacity</span>
+                  <button
+                    type="button"
+                    class="material-section__help-button"
+                    aria-label="The Opacity section switches between a scalar slider, a dedicated texture, or the base color's alpha channel to drive transparency."
+                    data-section-help
+                    data-tooltip="Control transparency with a slider, a separate texture, or the base color's alpha channel."
+                  >
+                    ?
+                  </button>
+                </span>
+              </summary>
               <div class="material-section__content">
                 <div class="material-mode" role="radiogroup">
                   <label class="material-mode__option">
@@ -184,21 +210,34 @@
                       width="100"
                       height="100"
                     />
-                      <div class="texture-upload__label">Alpha</div>
+                    <div class="texture-upload__label">Alpha</div>
                   </div>
                   <p class="material-opacity__note">Uses the base color texture alpha channel.</p>
                 </div>
               </div>
             </details>
             <details class="material-section" open>
-              <summary class="material-section__summary">Normal Map</summary>
+              <summary class="material-section__summary">
+                <span class="material-section__label">
+                  <span>Normal Map</span>
+                  <button
+                    type="button"
+                    class="material-section__help-button"
+                    aria-label="The Normal Map section lets you upload a normal texture and adjust its strength. A neutral normal map is used when none is provided."
+                    data-section-help
+                    data-tooltip="Upload a normal map and adjust its strength. A neutral normal map is used if none is supplied."
+                  >
+                    ?
+                  </button>
+                </span>
+              </summary>
               <div class="material-section__content">
                 <div class="material-control material-control--normal">
                   <div class="texture-upload" data-normal-texture-target>
                     <img
                       class="texture-upload__image"
                       data-normal-texture-image
-                      alt="Предпросмотр нормал-карты"
+                      alt="Normal map preview"
                       width="100"
                       height="100"
                     />
@@ -206,7 +245,7 @@
                       type="button"
                       class="texture-upload__remove"
                       data-normal-texture-remove
-                      aria-label="Удалить нормал-карту"
+                      aria-label="Remove normal map"
                     >
                       ×
                     </button>
@@ -240,7 +279,20 @@
               </div>
             </details>
             <details class="material-section" open>
-              <summary class="material-section__summary">Occlusion / Metallic / Roughness</summary>
+              <summary class="material-section__summary">
+                <span class="material-section__label">
+                  <span>Occlusion / Metallic / Roughness</span>
+                  <button
+                    type="button"
+                    class="material-section__help-button"
+                    aria-label="The ORM section manages ambient occlusion, metallic, and roughness. Use a packed ORM texture, separate textures per channel, or scalar values."
+                    data-section-help
+                    data-tooltip="Manage occlusion, metallic, and roughness using a packed ORM map, separate textures, or scalar values per channel."
+                  >
+                    ?
+                  </button>
+                </span>
+              </summary>
               <div class="material-section__content">
                 <div class="material-mode" role="radiogroup">
                   <label class="material-mode__option">
@@ -261,7 +313,7 @@
                     <img
                       class="texture-upload__image"
                       data-orm-packed-image
-                      alt="Предпросмотр ORM текстуры"
+                      alt="Packed ORM texture preview"
                       width="100"
                       height="100"
                     />
@@ -269,7 +321,7 @@
                       type="button"
                       class="texture-upload__remove"
                       data-orm-packed-remove
-                      aria-label="Удалить ORM текстуру"
+                      aria-label="Remove packed ORM texture"
                     >
                       ×
                     </button>
@@ -285,7 +337,7 @@
                         <img
                           class="texture-upload__image"
                           data-orm-ao-image
-                          alt="Предпросмотр текстуры запекания"
+                          alt="Occlusion texture preview"
                           width="100"
                           height="100"
                         />
@@ -293,7 +345,7 @@
                           type="button"
                           class="texture-upload__remove"
                           data-orm-ao-remove
-                          aria-label="Удалить текстуру запекания"
+                          aria-label="Remove occlusion texture"
                         >
                           ×
                         </button>
@@ -332,7 +384,7 @@
                         <img
                           class="texture-upload__image"
                           data-orm-metalness-image
-                          alt="Предпросмотр металлической текстуры"
+                          alt="Metallic texture preview"
                           width="100"
                           height="100"
                         />
@@ -340,7 +392,7 @@
                           type="button"
                           class="texture-upload__remove"
                           data-orm-metalness-remove
-                          aria-label="Удалить металлическую текстуру"
+                          aria-label="Remove metallic texture"
                         >
                           ×
                         </button>
@@ -379,7 +431,7 @@
                         <img
                           class="texture-upload__image"
                           data-orm-roughness-image
-                          alt="Предпросмотр текстуры шероховатости"
+                          alt="Roughness texture preview"
                           width="100"
                           height="100"
                         />
@@ -387,7 +439,7 @@
                           type="button"
                           class="texture-upload__remove"
                           data-orm-roughness-remove
-                          aria-label="Удалить текстуру шероховатости"
+                          aria-label="Remove roughness texture"
                         >
                           ×
                         </button>
@@ -428,7 +480,7 @@
                         <img
                           class="texture-upload__image"
                           data-orm-scalar-ao-image
-                          alt="Предпросмотр интенсивности запекания"
+                          alt="Occlusion value preview"
                           width="100"
                           height="100"
                         />
@@ -466,7 +518,7 @@
                         <img
                           class="texture-upload__image"
                           data-orm-scalar-metalness-image
-                          alt="Предпросмотр металлического значения"
+                          alt="Metallic value preview"
                           width="100"
                           height="100"
                         />
@@ -504,7 +556,7 @@
                         <img
                           class="texture-upload__image"
                           data-orm-scalar-roughness-image
-                          alt="Предпросмотр значения шероховатости"
+                          alt="Roughness value preview"
                           width="100"
                           height="100"
                         />
@@ -539,7 +591,20 @@
               </div>
             </details>
             <details class="material-section" data-baked-section>
-              <summary class="material-section__summary">Baked Textures</summary>
+              <summary class="material-section__summary">
+                <span class="material-section__label">
+                  <span>Baked Textures</span>
+                  <button
+                    type="button"
+                    class="material-section__help-button"
+                    aria-label="Baked textures show how the color, normal, and ORM outputs will be exported based on current settings."
+                    data-section-help
+                    data-tooltip="Review the baked color, normal, and ORM textures that will be exported from the current material setup."
+                  >
+                    ?
+                  </button>
+                </span>
+              </summary>
               <div class="material-section__content">
                 <div class="material-baked">
                   <div class="material-baked__item">

--- a/index.html
+++ b/index.html
@@ -524,6 +524,49 @@
                 </div>
               </div>
             </details>
+            <details class="material-section" data-baked-section>
+              <summary class="material-section__summary">Baked Textures</summary>
+              <div class="material-section__content">
+                <div class="material-baked">
+                  <div class="material-baked__item">
+                    <p class="material-baked__label">Color</p>
+                    <div class="texture-upload texture-upload--readonly">
+                      <img
+                        class="texture-upload__image"
+                        data-baked-color-image
+                        alt="Baked color preview"
+                        width="100"
+                        height="100"
+                      />
+                    </div>
+                  </div>
+                  <div class="material-baked__item">
+                    <p class="material-baked__label">Normal</p>
+                    <div class="texture-upload texture-upload--readonly">
+                      <img
+                        class="texture-upload__image"
+                        data-baked-normal-image
+                        alt="Baked normal preview"
+                        width="100"
+                        height="100"
+                      />
+                    </div>
+                  </div>
+                  <div class="material-baked__item">
+                    <p class="material-baked__label">ORM</p>
+                    <div class="texture-upload texture-upload--readonly">
+                      <img
+                        class="texture-upload__image"
+                        data-baked-orm-image
+                        alt="Baked ORM preview"
+                        width="100"
+                        height="100"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </details>
           </div>
         </div>
       </aside>

--- a/index.html
+++ b/index.html
@@ -94,13 +94,15 @@
                     ?
                   </button>
                 </span>
-                <select class="info-field__input" data-info-placement>
-                  <option value="all" data-i18n-key="placement.options.all">All</option>
-                  <option value="floor" data-i18n-key="placement.options.floor">Floor</option>
-                  <option value="wall" data-i18n-key="placement.options.wall">Wall</option>
-                  <option value="ceiling" data-i18n-key="placement.options.ceiling">Ceiling</option>
-                  <option value="carpet" data-i18n-key="placement.options.carpet">Carpet</option>
-                </select>
+                <div class="info-field__select">
+                  <select class="info-field__input info-field__input--select" data-info-placement>
+                    <option value="all" data-i18n-key="placement.options.all">All</option>
+                    <option value="floor" data-i18n-key="placement.options.floor">Floor</option>
+                    <option value="wall" data-i18n-key="placement.options.wall">Wall</option>
+                    <option value="ceiling" data-i18n-key="placement.options.ceiling">Ceiling</option>
+                    <option value="carpet" data-i18n-key="placement.options.carpet">Carpet</option>
+                  </select>
+                </div>
               </label>
             </div>
             <div class="info-panel__group">
@@ -151,17 +153,21 @@
                     ?
                   </button>
                 </span>
-                <select class="info-field__input" data-info-category>
-                  <option value="" data-i18n-key="category.placeholder">Select category</option>
-                </select>
+                <div class="info-field__select">
+                  <select class="info-field__input info-field__input--select" data-info-category>
+                    <option value="" data-i18n-key="category.placeholder">Select category</option>
+                  </select>
+                </div>
               </label>
             </div>
             <div class="info-panel__group" data-info-subcategory-group>
               <label class="info-field">
                 <span class="info-field__label" data-i18n-key="subcategory.label">Subcategory</span>
-                <select class="info-field__input" data-info-subcategory>
-                  <option value="" data-i18n-key="subcategory.placeholder">Select subcategory</option>
-                </select>
+                <div class="info-field__select">
+                  <select class="info-field__input info-field__input--select" data-info-subcategory>
+                    <option value="" data-i18n-key="subcategory.placeholder">Select subcategory</option>
+                  </select>
+                </div>
               </label>
             </div>
             <div class="info-panel__group">
@@ -178,11 +184,13 @@
                     ?
                   </button>
                 </span>
-                <select class="info-field__input" data-info-visibility>
-                  <option value="visible" data-i18n-key="visibility.options.visible">Visible everywhere</option>
-                  <option value="catalogs" data-i18n-key="visibility.options.catalogs">Only in my catalogs</option>
-                  <option value="hidden" data-i18n-key="visibility.options.hidden">Hidden everywhere</option>
-                </select>
+                <div class="info-field__select">
+                  <select class="info-field__input info-field__input--select" data-info-visibility>
+                    <option value="visible" data-i18n-key="visibility.options.visible">Visible everywhere</option>
+                    <option value="catalogs" data-i18n-key="visibility.options.catalogs">Only in my catalogs</option>
+                    <option value="hidden" data-i18n-key="visibility.options.hidden">Hidden everywhere</option>
+                  </select>
+                </div>
               </label>
             </div>
             <div class="info-panel__group">

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
   <body>
     <div id="app">
       <canvas id="scene"></canvas>
-      <aside class="panel" data-panel>
+      <aside class="panel panel--left" data-panel>
         <div class="panel__import">
           <button class="panel__import-button" type="button" data-import-button>Import Model</button>
           <input
@@ -49,6 +49,93 @@
           <input type="number" step="0.01" class="inspector__input" data-axis="z" placeholder="Z" />
         </div>
       </div>
+      <aside class="panel panel--right" data-material-panel>
+        <div class="material-panel">
+          <p class="material-panel__title">Материал</p>
+          <p class="material-panel__message" data-material-message>Выберите один меш для настройки материала.</p>
+          <div class="material-panel__body is-hidden" data-material-body>
+            <details class="material-section" open>
+              <summary class="material-section__summary">Цвет</summary>
+              <div class="material-section__content">
+                <div class="material-mode" role="radiogroup">
+                  <label class="material-mode__option">
+                    <input type="radio" name="color-mode" value="color" data-color-mode />
+                    <span>Цвет</span>
+                  </label>
+                  <label class="material-mode__option">
+                    <input type="radio" name="color-mode" value="texture" data-color-mode />
+                    <span>Текстура</span>
+                  </label>
+                </div>
+                <div class="material-color-picker" data-color-picker>
+                  <label class="material-field">
+                    <span class="material-field__label">Базовый цвет</span>
+                    <input type="color" class="material-field__input" data-color-input />
+                  </label>
+                </div>
+                <div class="material-texture-picker is-hidden" data-color-texture>
+                  <div class="texture-upload" data-color-texture-target>
+                    <img
+                      class="texture-upload__image"
+                      data-color-texture-image
+                      alt="Предпросмотр текстуры цвета"
+                      width="100"
+                      height="100"
+                    />
+                    <button
+                      type="button"
+                      class="texture-upload__remove"
+                      data-color-texture-remove
+                      aria-label="Удалить текстуру"
+                    >
+                      ×
+                    </button>
+                    <div class="texture-upload__label">Upload</div>
+                    <input class="hidden-input" type="file" accept="image/*" data-color-texture-input />
+                  </div>
+                </div>
+              </div>
+            </details>
+            <details class="material-section" open>
+              <summary class="material-section__summary">Normal Map</summary>
+              <div class="material-section__content">
+                <div class="texture-upload" data-normal-texture-target>
+                  <img
+                    class="texture-upload__image"
+                    data-normal-texture-image
+                    alt="Предпросмотр нормал-карты"
+                    width="100"
+                    height="100"
+                  />
+                  <button
+                    type="button"
+                    class="texture-upload__remove"
+                    data-normal-texture-remove
+                    aria-label="Удалить нормал-карту"
+                  >
+                    ×
+                  </button>
+                  <div class="texture-upload__label">Upload</div>
+                  <input class="hidden-input" type="file" accept="image/*" data-normal-texture-input />
+                </div>
+                <label class="material-slider">
+                  <span class="material-slider__label">Сила</span>
+                  <input
+                    type="range"
+                    min="0"
+                    max="3"
+                    step="0.05"
+                    value="1"
+                    class="material-slider__input"
+                    data-normal-strength
+                  />
+                  <span class="material-slider__value" data-normal-strength-value>1.00</span>
+                </label>
+              </div>
+            </details>
+          </div>
+        </div>
+      </aside>
     </div>
     <script type="module" src="./src/main.js"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
                   <span data-i18n-key="placement.label">Placement type</span>
                   <button
                     type="button"
-                    class="info-field__help"
+                    class="material-section__help-button"
                     aria-label="Placement type description"
                     data-tooltip-button
                     data-i18n-tooltip="placement.help"
@@ -111,7 +111,7 @@
                   <span data-i18n-key="destination.label">Destination Url</span>
                   <button
                     type="button"
-                    class="info-field__help"
+                    class="material-section__help-button"
                     aria-label="Destination url description"
                     data-tooltip-button
                     data-i18n-tooltip="destination.help"
@@ -145,7 +145,7 @@
                   <span data-i18n-key="category.label">Category</span>
                   <button
                     type="button"
-                    class="info-field__help"
+                    class="material-section__help-button"
                     aria-label="Category description"
                     data-tooltip-button
                     data-i18n-tooltip="category.help"
@@ -176,7 +176,7 @@
                   <span data-i18n-key="visibility.label">Visibility</span>
                   <button
                     type="button"
-                    class="info-field__help"
+                    class="material-section__help-button"
                     aria-label="Visibility description"
                     data-tooltip-button
                     data-i18n-tooltip="visibility.help"

--- a/index.html
+++ b/index.html
@@ -24,17 +24,208 @@
     <div id="app">
       <canvas id="scene"></canvas>
       <aside class="panel panel--left" data-panel>
-        <div class="panel__import">
-          <button class="panel__import-button" type="button" data-import-button>Import Model</button>
-          <button class="panel__select-all-button" type="button" data-select-all>Select All Meshes</button>
-          <input
-            class="hidden-input"
-            type="file"
-            accept=".gltf,.glb,.fbx,.obj"
-            data-file-input
-          />
+        <div class="panel__tabs" role="tablist">
+          <button
+            type="button"
+            class="panel__tab panel__tab--active"
+            data-panel-tab="info"
+            data-i18n-key="tabs.info"
+          >
+            Info
+          </button>
+          <button
+            type="button"
+            class="panel__tab"
+            data-panel-tab="mesh"
+            data-i18n-key="tabs.mesh"
+          >
+            Mesh
+          </button>
         </div>
-        <ul class="panel__list" data-mesh-list></ul>
+        <section
+          class="panel__section panel__section--info panel__section--active"
+          data-panel-section="info"
+        >
+          <div class="info-panel" data-info-panel>
+            <div class="info-panel__group info-panel__group--language">
+              <label class="info-field">
+                <span class="info-field__label" data-i18n-key="language.label">Language</span>
+                <select class="info-field__input" data-info-language>
+                  <option value="en">English</option>
+                  <option value="ru">Русский</option>
+                </select>
+              </label>
+            </div>
+            <div class="info-panel__group">
+              <label class="info-field">
+                <span class="info-field__label">
+                  <span data-i18n-key="placement.label">Placement type</span>
+                  <button
+                    type="button"
+                    class="info-field__help"
+                    aria-label="Placement type description"
+                    data-tooltip-button
+                    data-i18n-tooltip="placement.help"
+                  >
+                    ?
+                  </button>
+                </span>
+                <select class="info-field__input" data-info-placement>
+                  <option value="all" data-i18n-key="placement.options.all">All</option>
+                  <option value="floor" data-i18n-key="placement.options.floor">Floor</option>
+                  <option value="wall" data-i18n-key="placement.options.wall">Wall</option>
+                  <option value="ceiling" data-i18n-key="placement.options.ceiling">Ceiling</option>
+                  <option value="carpet" data-i18n-key="placement.options.carpet">Carpet</option>
+                </select>
+              </label>
+            </div>
+            <div class="info-panel__group">
+              <label class="info-field">
+                <span class="info-field__label">
+                  <span data-i18n-key="destination.label">Destination Url</span>
+                  <button
+                    type="button"
+                    class="info-field__help"
+                    aria-label="Destination url description"
+                    data-tooltip-button
+                    data-i18n-tooltip="destination.help"
+                  >
+                    ?
+                  </button>
+                </span>
+                <input
+                  type="url"
+                  class="info-field__input"
+                  placeholder="https://"
+                  data-info-destination
+                  data-i18n-placeholder="destination.placeholder"
+                />
+              </label>
+            </div>
+            <div class="info-panel__group info-panel__group--split">
+              <label class="info-field">
+                <span class="info-field__label" data-i18n-key="brand.label">Brand</span>
+                <input
+                  type="text"
+                  class="info-field__input"
+                  data-info-brand
+                  data-i18n-placeholder="brand.placeholder"
+                />
+              </label>
+              <label class="info-field">
+                <span class="info-field__label">
+                  <span data-i18n-key="category.label">Category</span>
+                  <button
+                    type="button"
+                    class="info-field__help"
+                    aria-label="Category description"
+                    data-tooltip-button
+                    data-i18n-tooltip="category.help"
+                  >
+                    ?
+                  </button>
+                </span>
+                <select class="info-field__input" data-info-category>
+                  <option value="" data-i18n-key="category.placeholder">Select category</option>
+                </select>
+              </label>
+            </div>
+            <div class="info-panel__group info-panel__group--split" data-info-subcategory-group>
+              <label class="info-field">
+                <span class="info-field__label" data-i18n-key="subcategory.label">Subcategory</span>
+                <select class="info-field__input" data-info-subcategory>
+                  <option value="" data-i18n-key="subcategory.placeholder">Select subcategory</option>
+                </select>
+              </label>
+              <div class="info-panel__preview" data-info-category-preview>
+                <img alt="" data-info-category-image width="100" height="100" />
+                <span class="info-panel__preview-label" data-i18n-key="subcategory.previewLabel">Preview</span>
+              </div>
+            </div>
+            <div class="info-panel__group">
+              <div class="info-field info-field--stacked">
+                <div class="info-field__label info-field__label--split">
+                  <span data-i18n-key="color.label">Color miniature</span>
+                  <button
+                    type="button"
+                    class="info-field__help"
+                    aria-label="Color miniature description"
+                    data-tooltip-button
+                    data-i18n-tooltip="color.help"
+                  >
+                    ?
+                  </button>
+                </div>
+                <div class="info-panel__color-grid" data-info-color-grid></div>
+              </div>
+            </div>
+            <div class="info-panel__group">
+              <label class="info-field">
+                <span class="info-field__label">
+                  <span data-i18n-key="visibility.label">Visibility</span>
+                  <button
+                    type="button"
+                    class="info-field__help"
+                    aria-label="Visibility description"
+                    data-tooltip-button
+                    data-i18n-tooltip="visibility.help"
+                  >
+                    ?
+                  </button>
+                </span>
+                <select class="info-field__input" data-info-visibility>
+                  <option value="visible" data-i18n-key="visibility.options.visible">Visible everywhere</option>
+                  <option value="catalogs" data-i18n-key="visibility.options.catalogs">Only in my catalogs</option>
+                  <option value="hidden" data-i18n-key="visibility.options.hidden">Hidden everywhere</option>
+                </select>
+              </label>
+            </div>
+            <div class="info-panel__group">
+              <div class="info-field info-field--stacked">
+                <div class="info-field__label" data-i18n-key="covers.label">Covers</div>
+                <div class="info-panel__covers" data-info-covers>
+                  <label class="texture-upload texture-upload--cover" data-info-cover-target>
+                    <img
+                      class="texture-upload__image"
+                      data-info-cover-image
+                      alt="Cover preview"
+                      width="100"
+                      height="100"
+                    />
+                    <button
+                      type="button"
+                      class="texture-upload__remove"
+                      data-info-cover-remove
+                      aria-label="Remove cover"
+                    >
+                      ×
+                    </button>
+                    <div class="texture-upload__label" data-i18n-key="covers.add">Add Cover</div>
+                    <input class="hidden-input" type="file" accept="image/*" data-info-cover-input />
+                  </label>
+                </div>
+              </div>
+            </div>
+            <div class="info-panel__group info-panel__group--actions">
+              <button type="button" class="info-panel__delete" data-info-delete>
+                <span data-i18n-key="delete.label">Delete object</span>
+              </button>
+            </div>
+          </div>
+        </section>
+        <section class="panel__section panel__section--mesh" data-panel-section="mesh">
+          <div class="panel__import">
+            <button class="panel__import-button" type="button" data-import-button>Import Model</button>
+            <button class="panel__select-all-button" type="button" data-select-all>Select All Meshes</button>
+            <input
+              class="hidden-input"
+              type="file"
+              accept=".gltf,.glb,.fbx,.obj"
+              data-file-input
+            />
+          </div>
+          <ul class="panel__list" data-mesh-list></ul>
+        </section>
       </aside>
       <div class="toolbar" data-toolbar>
         <button type="button" class="toolbar__button active" data-mode="none">None</button>

--- a/index.html
+++ b/index.html
@@ -81,9 +81,15 @@
               </label>
             </div>
             <div class="info-panel__group">
-              <label class="info-field">
-                <span class="info-field__label material-section__label">
-                  <span data-i18n-key="placement.label">Placement type</span>
+              <div class="info-field">
+                <div class="info-field__header material-section__label">
+                  <label
+                    class="info-field__label"
+                    for="info-placement"
+                    data-i18n-key="placement.label"
+                  >
+                    Placement type
+                  </label>
                   <button
                     type="button"
                     class="material-section__help-button"
@@ -93,9 +99,13 @@
                   >
                     ?
                   </button>
-                </span>
+                </div>
                 <div class="info-field__select">
-                  <select class="info-field__input info-field__input--select" data-info-placement>
+                  <select
+                    id="info-placement"
+                    class="info-field__input info-field__input--select"
+                    data-info-placement
+                  >
                     <option value="all" data-i18n-key="placement.options.all">All</option>
                     <option value="floor" data-i18n-key="placement.options.floor">Floor</option>
                     <option value="wall" data-i18n-key="placement.options.wall">Wall</option>
@@ -103,12 +113,18 @@
                     <option value="carpet" data-i18n-key="placement.options.carpet">Carpet</option>
                   </select>
                 </div>
-              </label>
+              </div>
             </div>
             <div class="info-panel__group">
-              <label class="info-field">
-                <span class="info-field__label material-section__label">
-                  <span data-i18n-key="destination.label">Destination Url</span>
+              <div class="info-field">
+                <div class="info-field__header material-section__label">
+                  <label
+                    class="info-field__label"
+                    for="info-destination"
+                    data-i18n-key="destination.label"
+                  >
+                    Destination Url
+                  </label>
                   <button
                     type="button"
                     class="material-section__help-button"
@@ -118,15 +134,16 @@
                   >
                     ?
                   </button>
-                </span>
+                </div>
                 <input
                   type="url"
                   class="info-field__input"
+                  id="info-destination"
                   placeholder="https://"
                   data-info-destination
                   data-i18n-placeholder="destination.placeholder"
                 />
-              </label>
+              </div>
             </div>
             <div class="info-panel__group">
               <label class="info-field">
@@ -140,9 +157,15 @@
               </label>
             </div>
             <div class="info-panel__group">
-              <label class="info-field">
-                <span class="info-field__label material-section__label">
-                  <span data-i18n-key="category.label">Category</span>
+              <div class="info-field">
+                <div class="info-field__header material-section__label">
+                  <label
+                    class="info-field__label"
+                    for="info-category"
+                    data-i18n-key="category.label"
+                  >
+                    Category
+                  </label>
                   <button
                     type="button"
                     class="material-section__help-button"
@@ -152,28 +175,42 @@
                   >
                     ?
                   </button>
-                </span>
+                </div>
                 <div class="info-field__select">
-                  <select class="info-field__input info-field__input--select" data-info-category>
+                  <select
+                    id="info-category"
+                    class="info-field__input info-field__input--select"
+                    data-info-category
+                  >
                     <option value="" data-i18n-key="category.placeholder">Select category</option>
                   </select>
                 </div>
-              </label>
+              </div>
             </div>
             <div class="info-panel__group" data-info-subcategory-group>
               <label class="info-field">
                 <span class="info-field__label" data-i18n-key="subcategory.label">Subcategory</span>
                 <div class="info-field__select">
-                  <select class="info-field__input info-field__input--select" data-info-subcategory>
+                  <select
+                    id="info-subcategory"
+                    class="info-field__input info-field__input--select"
+                    data-info-subcategory
+                  >
                     <option value="" data-i18n-key="subcategory.placeholder">Select subcategory</option>
                   </select>
                 </div>
               </label>
             </div>
             <div class="info-panel__group">
-              <label class="info-field">
-                <span class="info-field__label material-section__label">
-                  <span data-i18n-key="visibility.label">Visibility</span>
+              <div class="info-field">
+                <div class="info-field__header material-section__label">
+                  <label
+                    class="info-field__label"
+                    for="info-visibility"
+                    data-i18n-key="visibility.label"
+                  >
+                    Visibility
+                  </label>
                   <button
                     type="button"
                     class="material-section__help-button"
@@ -183,15 +220,19 @@
                   >
                     ?
                   </button>
-                </span>
+                </div>
                 <div class="info-field__select">
-                  <select class="info-field__input info-field__input--select" data-info-visibility>
+                  <select
+                    id="info-visibility"
+                    class="info-field__input info-field__input--select"
+                    data-info-visibility
+                  >
                     <option value="visible" data-i18n-key="visibility.options.visible">Visible everywhere</option>
                     <option value="catalogs" data-i18n-key="visibility.options.catalogs">Only in my catalogs</option>
                     <option value="hidden" data-i18n-key="visibility.options.hidden">Hidden everywhere</option>
                   </select>
                 </div>
-              </label>
+              </div>
             </div>
             <div class="info-panel__group">
               <div class="info-field info-field--stacked">

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
                     <span>Color Alpha</span>
                   </label>
                 </div>
-                <div class="material-opacity material-opacity--slider" data-opacity-slider>
+                <div class="material-opacity material-opacity--slider material-control" data-opacity-slider>
                   <div class="texture-upload texture-upload--readonly" data-opacity-slider-target>
                     <img
                       class="texture-upload__image"
@@ -193,47 +193,49 @@
             <details class="material-section" open>
               <summary class="material-section__summary">Normal Map</summary>
               <div class="material-section__content">
-                <div class="texture-upload" data-normal-texture-target>
-                  <img
-                    class="texture-upload__image"
-                    data-normal-texture-image
-                    alt="Предпросмотр нормал-карты"
-                    width="100"
-                    height="100"
-                  />
-                  <button
-                    type="button"
-                    class="texture-upload__remove"
-                    data-normal-texture-remove
-                    aria-label="Удалить нормал-карту"
-                  >
-                    ×
-                  </button>
-                  <div class="texture-upload__label">Upload</div>
-                  <input class="hidden-input" type="file" accept="image/*" data-normal-texture-input />
-                </div>
-                <div class="material-slider">
-                  <label class="material-slider__label" for="normal-strength-slider">Strength</label>
-                  <input
-                    id="normal-strength-slider"
-                    type="range"
-                    min="0"
-                    max="3"
-                    step="0.05"
-                    value="1"
-                    class="material-slider__input"
-                    data-normal-strength
-                  />
-                  <input
-                    type="number"
-                    min="0"
-                    max="3"
-                    step="0.05"
-                    value="1.00"
-                    class="material-slider__value"
-                    data-normal-strength-number
-                    aria-label="Normal map strength"
-                  />
+                <div class="material-control material-control--normal">
+                  <div class="texture-upload" data-normal-texture-target>
+                    <img
+                      class="texture-upload__image"
+                      data-normal-texture-image
+                      alt="Предпросмотр нормал-карты"
+                      width="100"
+                      height="100"
+                    />
+                    <button
+                      type="button"
+                      class="texture-upload__remove"
+                      data-normal-texture-remove
+                      aria-label="Удалить нормал-карту"
+                    >
+                      ×
+                    </button>
+                    <div class="texture-upload__label">Upload</div>
+                    <input class="hidden-input" type="file" accept="image/*" data-normal-texture-input />
+                  </div>
+                  <div class="material-slider material-slider--stacked">
+                    <label class="material-slider__label" for="normal-strength-slider">Strength</label>
+                    <input
+                      id="normal-strength-slider"
+                      type="range"
+                      min="0"
+                      max="3"
+                      step="0.05"
+                      value="1"
+                      class="material-slider__input"
+                      data-normal-strength
+                    />
+                    <input
+                      type="number"
+                      min="0"
+                      max="3"
+                      step="0.05"
+                      value="1.00"
+                      class="material-slider__value"
+                      data-normal-strength-number
+                      aria-label="Normal map strength"
+                    />
+                  </div>
                 </div>
               </div>
             </details>
@@ -278,247 +280,259 @@
                 <div class="material-orm material-orm--separate is-hidden" data-orm-separate>
                   <div class="material-orm__channel" data-orm-channel="ao">
                     <p class="material-orm__label">Occlusion</p>
-                    <div class="texture-upload" data-orm-ao-target>
-                      <img
-                        class="texture-upload__image"
-                        data-orm-ao-image
-                        alt="Предпросмотр текстуры запекания"
-                        width="100"
-                        height="100"
-                      />
-                      <button
-                        type="button"
-                        class="texture-upload__remove"
-                        data-orm-ao-remove
-                        aria-label="Удалить текстуру запекания"
-                      >
-                        ×
-                      </button>
-                      <div class="texture-upload__label">Upload</div>
-                      <input class="hidden-input" type="file" accept="image/*" data-orm-ao-input />
-                    </div>
-                    <div class="material-slider material-slider--stacked is-hidden" data-orm-ao-scalar>
-                      <label class="material-slider__label" for="orm-ao-slider">Intensity</label>
-                      <input
-                        id="orm-ao-slider"
-                        type="range"
-                        min="0"
-                        max="1"
-                        step="0.01"
-                        value="1"
-                        class="material-slider__input"
-                        data-orm-ao-slider
-                      />
-                      <input
-                        type="number"
-                        min="0"
-                        max="1"
-                        step="0.01"
-                        value="1.00"
-                        class="material-slider__value"
-                        data-orm-ao-number
-                        aria-label="Occlusion intensity"
-                      />
+                    <div class="material-control material-control--channel">
+                      <div class="texture-upload" data-orm-ao-target>
+                        <img
+                          class="texture-upload__image"
+                          data-orm-ao-image
+                          alt="Предпросмотр текстуры запекания"
+                          width="100"
+                          height="100"
+                        />
+                        <button
+                          type="button"
+                          class="texture-upload__remove"
+                          data-orm-ao-remove
+                          aria-label="Удалить текстуру запекания"
+                        >
+                          ×
+                        </button>
+                        <div class="texture-upload__label">Upload</div>
+                        <input class="hidden-input" type="file" accept="image/*" data-orm-ao-input />
+                      </div>
+                      <div class="material-slider material-slider--stacked is-hidden" data-orm-ao-scalar>
+                        <label class="material-slider__label" for="orm-ao-slider">Intensity</label>
+                        <input
+                          id="orm-ao-slider"
+                          type="range"
+                          min="0"
+                          max="1"
+                          step="0.01"
+                          value="1"
+                          class="material-slider__input"
+                          data-orm-ao-slider
+                        />
+                        <input
+                          type="number"
+                          min="0"
+                          max="1"
+                          step="0.01"
+                          value="1.00"
+                          class="material-slider__value"
+                          data-orm-ao-number
+                          aria-label="Occlusion intensity"
+                        />
+                      </div>
                     </div>
                   </div>
                   <div class="material-orm__channel" data-orm-channel="metalness">
                     <p class="material-orm__label">Metallic</p>
-                    <div class="texture-upload" data-orm-metalness-target>
-                      <img
-                        class="texture-upload__image"
-                        data-orm-metalness-image
-                        alt="Предпросмотр металлической текстуры"
-                        width="100"
-                        height="100"
-                      />
-                      <button
-                        type="button"
-                        class="texture-upload__remove"
-                        data-orm-metalness-remove
-                        aria-label="Удалить металлическую текстуру"
-                      >
-                        ×
-                      </button>
-                      <div class="texture-upload__label">Upload</div>
-                      <input class="hidden-input" type="file" accept="image/*" data-orm-metalness-input />
-                    </div>
-                    <div class="material-slider material-slider--stacked is-hidden" data-orm-metalness-scalar>
-                      <label class="material-slider__label" for="orm-metalness-slider">Metalness</label>
-                      <input
-                        id="orm-metalness-slider"
-                        type="range"
-                        min="0"
-                        max="1"
-                        step="0.01"
-                        value="0"
-                        class="material-slider__input"
-                        data-orm-metalness-slider
-                      />
-                      <input
-                        type="number"
-                        min="0"
-                        max="1"
-                        step="0.01"
-                        value="0.00"
-                        class="material-slider__value"
-                        data-orm-metalness-number
-                        aria-label="Metalness value"
-                      />
+                    <div class="material-control material-control--channel">
+                      <div class="texture-upload" data-orm-metalness-target>
+                        <img
+                          class="texture-upload__image"
+                          data-orm-metalness-image
+                          alt="Предпросмотр металлической текстуры"
+                          width="100"
+                          height="100"
+                        />
+                        <button
+                          type="button"
+                          class="texture-upload__remove"
+                          data-orm-metalness-remove
+                          aria-label="Удалить металлическую текстуру"
+                        >
+                          ×
+                        </button>
+                        <div class="texture-upload__label">Upload</div>
+                        <input class="hidden-input" type="file" accept="image/*" data-orm-metalness-input />
+                      </div>
+                      <div class="material-slider material-slider--stacked is-hidden" data-orm-metalness-scalar>
+                        <label class="material-slider__label" for="orm-metalness-slider">Metalness</label>
+                        <input
+                          id="orm-metalness-slider"
+                          type="range"
+                          min="0"
+                          max="1"
+                          step="0.01"
+                          value="0"
+                          class="material-slider__input"
+                          data-orm-metalness-slider
+                        />
+                        <input
+                          type="number"
+                          min="0"
+                          max="1"
+                          step="0.01"
+                          value="0.00"
+                          class="material-slider__value"
+                          data-orm-metalness-number
+                          aria-label="Metalness value"
+                        />
+                      </div>
                     </div>
                   </div>
                   <div class="material-orm__channel" data-orm-channel="roughness">
                     <p class="material-orm__label">Roughness</p>
-                    <div class="texture-upload" data-orm-roughness-target>
-                      <img
-                        class="texture-upload__image"
-                        data-orm-roughness-image
-                        alt="Предпросмотр текстуры шероховатости"
-                        width="100"
-                        height="100"
-                      />
-                      <button
-                        type="button"
-                        class="texture-upload__remove"
-                        data-orm-roughness-remove
-                        aria-label="Удалить текстуру шероховатости"
-                      >
-                        ×
-                      </button>
-                      <div class="texture-upload__label">Upload</div>
-                      <input class="hidden-input" type="file" accept="image/*" data-orm-roughness-input />
-                    </div>
-                    <div class="material-slider material-slider--stacked is-hidden" data-orm-roughness-scalar>
-                      <label class="material-slider__label" for="orm-roughness-slider">Roughness</label>
-                      <input
-                        id="orm-roughness-slider"
-                        type="range"
-                        min="0"
-                        max="1"
-                        step="0.01"
-                        value="1"
-                        class="material-slider__input"
-                        data-orm-roughness-slider
-                      />
-                      <input
-                        type="number"
-                        min="0"
-                        max="1"
-                        step="0.01"
-                        value="1.00"
-                        class="material-slider__value"
-                        data-orm-roughness-number
-                        aria-label="Roughness value"
-                      />
+                    <div class="material-control material-control--channel">
+                      <div class="texture-upload" data-orm-roughness-target>
+                        <img
+                          class="texture-upload__image"
+                          data-orm-roughness-image
+                          alt="Предпросмотр текстуры шероховатости"
+                          width="100"
+                          height="100"
+                        />
+                        <button
+                          type="button"
+                          class="texture-upload__remove"
+                          data-orm-roughness-remove
+                          aria-label="Удалить текстуру шероховатости"
+                        >
+                          ×
+                        </button>
+                        <div class="texture-upload__label">Upload</div>
+                        <input class="hidden-input" type="file" accept="image/*" data-orm-roughness-input />
+                      </div>
+                      <div class="material-slider material-slider--stacked is-hidden" data-orm-roughness-scalar>
+                        <label class="material-slider__label" for="orm-roughness-slider">Roughness</label>
+                        <input
+                          id="orm-roughness-slider"
+                          type="range"
+                          min="0"
+                          max="1"
+                          step="0.01"
+                          value="1"
+                          class="material-slider__input"
+                          data-orm-roughness-slider
+                        />
+                        <input
+                          type="number"
+                          min="0"
+                          max="1"
+                          step="0.01"
+                          value="1.00"
+                          class="material-slider__value"
+                          data-orm-roughness-number
+                          aria-label="Roughness value"
+                        />
+                      </div>
                     </div>
                   </div>
                 </div>
                 <div class="material-orm material-orm--scalar is-hidden" data-orm-scalar>
                   <div class="material-orm__channel" data-orm-scalar-channel="ao">
                     <p class="material-orm__label">Occlusion</p>
-                    <div class="texture-upload texture-upload--readonly">
-                      <img
-                        class="texture-upload__image"
-                        data-orm-scalar-ao-image
-                        alt="Предпросмотр интенсивности запекания"
-                        width="100"
-                        height="100"
-                      />
-                      <div class="texture-upload__label">Value</div>
-                    </div>
-                    <div class="material-slider material-slider--stacked" data-orm-scalar-ao>
-                      <label class="material-slider__label" for="orm-scalar-ao-slider">Intensity</label>
-                      <input
-                        id="orm-scalar-ao-slider"
-                        type="range"
-                        min="0"
-                        max="1"
-                        step="0.01"
-                        value="1"
-                        class="material-slider__input"
-                        data-orm-scalar-ao-slider
-                      />
-                      <input
-                        type="number"
-                        min="0"
-                        max="1"
-                        step="0.01"
-                        value="1.00"
-                        class="material-slider__value"
-                        data-orm-scalar-ao-number
-                        aria-label="Occlusion intensity"
-                      />
+                    <div class="material-control material-control--scalar" data-orm-scalar-ao-container>
+                      <div class="texture-upload texture-upload--readonly">
+                        <img
+                          class="texture-upload__image"
+                          data-orm-scalar-ao-image
+                          alt="Предпросмотр интенсивности запекания"
+                          width="100"
+                          height="100"
+                        />
+                        <div class="texture-upload__label">Value</div>
+                      </div>
+                      <div class="material-slider material-slider--stacked" data-orm-scalar-ao>
+                        <label class="material-slider__label" for="orm-scalar-ao-slider">Intensity</label>
+                        <input
+                          id="orm-scalar-ao-slider"
+                          type="range"
+                          min="0"
+                          max="1"
+                          step="0.01"
+                          value="1"
+                          class="material-slider__input"
+                          data-orm-scalar-ao-slider
+                        />
+                        <input
+                          type="number"
+                          min="0"
+                          max="1"
+                          step="0.01"
+                          value="1.00"
+                          class="material-slider__value"
+                          data-orm-scalar-ao-number
+                          aria-label="Occlusion intensity"
+                        />
+                      </div>
                     </div>
                   </div>
                   <div class="material-orm__channel" data-orm-scalar-channel="metalness">
                     <p class="material-orm__label">Metallic</p>
-                    <div class="texture-upload texture-upload--readonly">
-                      <img
-                        class="texture-upload__image"
-                        data-orm-scalar-metalness-image
-                        alt="Предпросмотр металлического значения"
-                        width="100"
-                        height="100"
-                      />
-                      <div class="texture-upload__label">Value</div>
-                    </div>
-                    <div class="material-slider material-slider--stacked" data-orm-scalar-metalness>
-                      <label class="material-slider__label" for="orm-scalar-metalness-slider">Metalness</label>
-                      <input
-                        id="orm-scalar-metalness-slider"
-                        type="range"
-                        min="0"
-                        max="1"
-                        step="0.01"
-                        value="0"
-                        class="material-slider__input"
-                        data-orm-scalar-metalness-slider
-                      />
-                      <input
-                        type="number"
-                        min="0"
-                        max="1"
-                        step="0.01"
-                        value="0.00"
-                        class="material-slider__value"
-                        data-orm-scalar-metalness-number
-                        aria-label="Metalness value"
-                      />
+                    <div class="material-control material-control--scalar" data-orm-scalar-metalness-container>
+                      <div class="texture-upload texture-upload--readonly">
+                        <img
+                          class="texture-upload__image"
+                          data-orm-scalar-metalness-image
+                          alt="Предпросмотр металлического значения"
+                          width="100"
+                          height="100"
+                        />
+                        <div class="texture-upload__label">Value</div>
+                      </div>
+                      <div class="material-slider material-slider--stacked" data-orm-scalar-metalness>
+                        <label class="material-slider__label" for="orm-scalar-metalness-slider">Metalness</label>
+                        <input
+                          id="orm-scalar-metalness-slider"
+                          type="range"
+                          min="0"
+                          max="1"
+                          step="0.01"
+                          value="0"
+                          class="material-slider__input"
+                          data-orm-scalar-metalness-slider
+                        />
+                        <input
+                          type="number"
+                          min="0"
+                          max="1"
+                          step="0.01"
+                          value="0.00"
+                          class="material-slider__value"
+                          data-orm-scalar-metalness-number
+                          aria-label="Metalness value"
+                        />
+                      </div>
                     </div>
                   </div>
                   <div class="material-orm__channel" data-orm-scalar-channel="roughness">
                     <p class="material-orm__label">Roughness</p>
-                    <div class="texture-upload texture-upload--readonly">
-                      <img
-                        class="texture-upload__image"
-                        data-orm-scalar-roughness-image
-                        alt="Предпросмотр значения шероховатости"
-                        width="100"
-                        height="100"
-                      />
-                      <div class="texture-upload__label">Value</div>
-                    </div>
-                    <div class="material-slider material-slider--stacked" data-orm-scalar-roughness>
-                      <label class="material-slider__label" for="orm-scalar-roughness-slider">Roughness</label>
-                      <input
-                        id="orm-scalar-roughness-slider"
-                        type="range"
-                        min="0"
-                        max="1"
-                        step="0.01"
-                        value="1"
-                        class="material-slider__input"
-                        data-orm-scalar-roughness-slider
-                      />
-                      <input
-                        type="number"
-                        min="0"
-                        max="1"
-                        step="0.01"
-                        value="1.00"
-                        class="material-slider__value"
-                        data-orm-scalar-roughness-number
-                        aria-label="Roughness value"
-                      />
+                    <div class="material-control material-control--scalar" data-orm-scalar-roughness-container>
+                      <div class="texture-upload texture-upload--readonly">
+                        <img
+                          class="texture-upload__image"
+                          data-orm-scalar-roughness-image
+                          alt="Предпросмотр значения шероховатости"
+                          width="100"
+                          height="100"
+                        />
+                        <div class="texture-upload__label">Value</div>
+                      </div>
+                      <div class="material-slider material-slider--stacked" data-orm-scalar-roughness>
+                        <label class="material-slider__label" for="orm-scalar-roughness-slider">Roughness</label>
+                        <input
+                          id="orm-scalar-roughness-slider"
+                          type="range"
+                          min="0"
+                          max="1"
+                          step="0.01"
+                          value="1"
+                          class="material-slider__input"
+                          data-orm-scalar-roughness-slider
+                        />
+                        <input
+                          type="number"
+                          min="0"
+                          max="1"
+                          step="0.01"
+                          value="1.00"
+                          class="material-slider__value"
+                          data-orm-scalar-roughness-number
+                          aria-label="Roughness value"
+                        />
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -149,6 +149,293 @@
                 </div>
               </div>
             </details>
+            <details class="material-section" open>
+              <summary class="material-section__summary">Occlusion / Metallic / Roughness</summary>
+              <div class="material-section__content">
+                <div class="material-mode" role="radiogroup">
+                  <label class="material-mode__option">
+                    <input type="radio" name="orm-mode" value="packed" data-orm-mode />
+                    <span>ORM Texture</span>
+                  </label>
+                  <label class="material-mode__option">
+                    <input type="radio" name="orm-mode" value="separate" data-orm-mode />
+                    <span>Separate</span>
+                  </label>
+                  <label class="material-mode__option">
+                    <input type="radio" name="orm-mode" value="scalar" data-orm-mode />
+                    <span>Scalar</span>
+                  </label>
+                </div>
+                <div class="material-orm material-orm--packed" data-orm-packed>
+                  <div class="texture-upload" data-orm-packed-target>
+                    <img
+                      class="texture-upload__image"
+                      data-orm-packed-image
+                      alt="Предпросмотр ORM текстуры"
+                      width="100"
+                      height="100"
+                    />
+                    <button
+                      type="button"
+                      class="texture-upload__remove"
+                      data-orm-packed-remove
+                      aria-label="Удалить ORM текстуру"
+                    >
+                      ×
+                    </button>
+                    <div class="texture-upload__label">Upload</div>
+                    <input class="hidden-input" type="file" accept="image/*" data-orm-packed-input />
+                  </div>
+                </div>
+                <div class="material-orm material-orm--separate is-hidden" data-orm-separate>
+                  <div class="material-orm__channel" data-orm-channel="ao">
+                    <p class="material-orm__label">Occlusion</p>
+                    <div class="texture-upload" data-orm-ao-target>
+                      <img
+                        class="texture-upload__image"
+                        data-orm-ao-image
+                        alt="Предпросмотр текстуры запекания"
+                        width="100"
+                        height="100"
+                      />
+                      <button
+                        type="button"
+                        class="texture-upload__remove"
+                        data-orm-ao-remove
+                        aria-label="Удалить текстуру запекания"
+                      >
+                        ×
+                      </button>
+                      <div class="texture-upload__label">Upload</div>
+                      <input class="hidden-input" type="file" accept="image/*" data-orm-ao-input />
+                    </div>
+                    <div class="material-slider material-slider--stacked is-hidden" data-orm-ao-scalar>
+                      <label class="material-slider__label" for="orm-ao-slider">Intensity</label>
+                      <input
+                        id="orm-ao-slider"
+                        type="range"
+                        min="0"
+                        max="1"
+                        step="0.01"
+                        value="1"
+                        class="material-slider__input"
+                        data-orm-ao-slider
+                      />
+                      <input
+                        type="number"
+                        min="0"
+                        max="1"
+                        step="0.01"
+                        value="1.00"
+                        class="material-slider__value"
+                        data-orm-ao-number
+                        aria-label="Occlusion intensity"
+                      />
+                    </div>
+                  </div>
+                  <div class="material-orm__channel" data-orm-channel="metalness">
+                    <p class="material-orm__label">Metallic</p>
+                    <div class="texture-upload" data-orm-metalness-target>
+                      <img
+                        class="texture-upload__image"
+                        data-orm-metalness-image
+                        alt="Предпросмотр металлической текстуры"
+                        width="100"
+                        height="100"
+                      />
+                      <button
+                        type="button"
+                        class="texture-upload__remove"
+                        data-orm-metalness-remove
+                        aria-label="Удалить металлическую текстуру"
+                      >
+                        ×
+                      </button>
+                      <div class="texture-upload__label">Upload</div>
+                      <input class="hidden-input" type="file" accept="image/*" data-orm-metalness-input />
+                    </div>
+                    <div class="material-slider material-slider--stacked is-hidden" data-orm-metalness-scalar>
+                      <label class="material-slider__label" for="orm-metalness-slider">Metalness</label>
+                      <input
+                        id="orm-metalness-slider"
+                        type="range"
+                        min="0"
+                        max="1"
+                        step="0.01"
+                        value="0"
+                        class="material-slider__input"
+                        data-orm-metalness-slider
+                      />
+                      <input
+                        type="number"
+                        min="0"
+                        max="1"
+                        step="0.01"
+                        value="0.00"
+                        class="material-slider__value"
+                        data-orm-metalness-number
+                        aria-label="Metalness value"
+                      />
+                    </div>
+                  </div>
+                  <div class="material-orm__channel" data-orm-channel="roughness">
+                    <p class="material-orm__label">Roughness</p>
+                    <div class="texture-upload" data-orm-roughness-target>
+                      <img
+                        class="texture-upload__image"
+                        data-orm-roughness-image
+                        alt="Предпросмотр текстуры шероховатости"
+                        width="100"
+                        height="100"
+                      />
+                      <button
+                        type="button"
+                        class="texture-upload__remove"
+                        data-orm-roughness-remove
+                        aria-label="Удалить текстуру шероховатости"
+                      >
+                        ×
+                      </button>
+                      <div class="texture-upload__label">Upload</div>
+                      <input class="hidden-input" type="file" accept="image/*" data-orm-roughness-input />
+                    </div>
+                    <div class="material-slider material-slider--stacked is-hidden" data-orm-roughness-scalar>
+                      <label class="material-slider__label" for="orm-roughness-slider">Roughness</label>
+                      <input
+                        id="orm-roughness-slider"
+                        type="range"
+                        min="0"
+                        max="1"
+                        step="0.01"
+                        value="1"
+                        class="material-slider__input"
+                        data-orm-roughness-slider
+                      />
+                      <input
+                        type="number"
+                        min="0"
+                        max="1"
+                        step="0.01"
+                        value="1.00"
+                        class="material-slider__value"
+                        data-orm-roughness-number
+                        aria-label="Roughness value"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div class="material-orm material-orm--scalar is-hidden" data-orm-scalar>
+                  <div class="material-orm__channel" data-orm-scalar-channel="ao">
+                    <p class="material-orm__label">Occlusion</p>
+                    <div class="texture-upload texture-upload--readonly">
+                      <img
+                        class="texture-upload__image"
+                        data-orm-scalar-ao-image
+                        alt="Предпросмотр интенсивности запекания"
+                        width="100"
+                        height="100"
+                      />
+                      <div class="texture-upload__label">Value</div>
+                    </div>
+                    <div class="material-slider material-slider--stacked" data-orm-scalar-ao>
+                      <label class="material-slider__label" for="orm-scalar-ao-slider">Intensity</label>
+                      <input
+                        id="orm-scalar-ao-slider"
+                        type="range"
+                        min="0"
+                        max="1"
+                        step="0.01"
+                        value="1"
+                        class="material-slider__input"
+                        data-orm-scalar-ao-slider
+                      />
+                      <input
+                        type="number"
+                        min="0"
+                        max="1"
+                        step="0.01"
+                        value="1.00"
+                        class="material-slider__value"
+                        data-orm-scalar-ao-number
+                        aria-label="Occlusion intensity"
+                      />
+                    </div>
+                  </div>
+                  <div class="material-orm__channel" data-orm-scalar-channel="metalness">
+                    <p class="material-orm__label">Metallic</p>
+                    <div class="texture-upload texture-upload--readonly">
+                      <img
+                        class="texture-upload__image"
+                        data-orm-scalar-metalness-image
+                        alt="Предпросмотр металлического значения"
+                        width="100"
+                        height="100"
+                      />
+                      <div class="texture-upload__label">Value</div>
+                    </div>
+                    <div class="material-slider material-slider--stacked" data-orm-scalar-metalness>
+                      <label class="material-slider__label" for="orm-scalar-metalness-slider">Metalness</label>
+                      <input
+                        id="orm-scalar-metalness-slider"
+                        type="range"
+                        min="0"
+                        max="1"
+                        step="0.01"
+                        value="0"
+                        class="material-slider__input"
+                        data-orm-scalar-metalness-slider
+                      />
+                      <input
+                        type="number"
+                        min="0"
+                        max="1"
+                        step="0.01"
+                        value="0.00"
+                        class="material-slider__value"
+                        data-orm-scalar-metalness-number
+                        aria-label="Metalness value"
+                      />
+                    </div>
+                  </div>
+                  <div class="material-orm__channel" data-orm-scalar-channel="roughness">
+                    <p class="material-orm__label">Roughness</p>
+                    <div class="texture-upload texture-upload--readonly">
+                      <img
+                        class="texture-upload__image"
+                        data-orm-scalar-roughness-image
+                        alt="Предпросмотр значения шероховатости"
+                        width="100"
+                        height="100"
+                      />
+                      <div class="texture-upload__label">Value</div>
+                    </div>
+                    <div class="material-slider material-slider--stacked" data-orm-scalar-roughness>
+                      <label class="material-slider__label" for="orm-scalar-roughness-slider">Roughness</label>
+                      <input
+                        id="orm-scalar-roughness-slider"
+                        type="range"
+                        min="0"
+                        max="1"
+                        step="0.01"
+                        value="1"
+                        class="material-slider__input"
+                        data-orm-scalar-roughness-slider
+                      />
+                      <input
+                        type="number"
+                        min="0"
+                        max="1"
+                        step="0.01"
+                        value="1.00"
+                        class="material-slider__value"
+                        data-orm-scalar-roughness-number
+                        aria-label="Roughness value"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </details>
           </div>
         </div>
       </aside>

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
       <aside class="panel panel--left" data-panel>
         <div class="panel__import">
           <button class="panel__import-button" type="button" data-import-button>Import Model</button>
+          <button class="panel__select-all-button" type="button" data-select-all>Select All Meshes</button>
           <input
             class="hidden-input"
             type="file"
@@ -48,6 +49,7 @@
           <input type="number" step="0.01" class="inspector__input" data-axis="y" placeholder="Y" />
           <input type="number" step="0.01" class="inspector__input" data-axis="z" placeholder="Z" />
         </div>
+        <button type="button" class="inspector__reset" data-inspector-reset>Reset Transform</button>
       </div>
       <aside class="panel panel--right" data-material-panel>
         <div class="material-panel">

--- a/index.html
+++ b/index.html
@@ -124,9 +124,10 @@
                   <div class="texture-upload__label">Upload</div>
                   <input class="hidden-input" type="file" accept="image/*" data-normal-texture-input />
                 </div>
-                <label class="material-slider">
-                  <span class="material-slider__label">Сила</span>
+                <div class="material-slider">
+                  <label class="material-slider__label" for="normal-strength-slider">Strength</label>
                   <input
+                    id="normal-strength-slider"
                     type="range"
                     min="0"
                     max="3"
@@ -135,8 +136,17 @@
                     class="material-slider__input"
                     data-normal-strength
                   />
-                  <span class="material-slider__value" data-normal-strength-value>1.00</span>
-                </label>
+                  <input
+                    type="number"
+                    min="0"
+                    max="3"
+                    step="0.05"
+                    value="1.00"
+                    class="material-slider__value"
+                    data-normal-strength-number
+                    aria-label="Normal map strength"
+                  />
+                </div>
               </div>
             </details>
           </div>

--- a/index.html
+++ b/index.html
@@ -23,6 +23,20 @@
   <body>
     <div id="app">
       <canvas id="scene"></canvas>
+      <div class="viewer-controls">
+        <label class="viewer-toggle">
+          <input
+            type="checkbox"
+            class="viewer-toggle__input"
+            data-dimension-toggle
+            aria-label="Toggle dimension helper"
+          />
+          <span class="viewer-toggle__switch" aria-hidden="true">
+            <span class="viewer-toggle__thumb"></span>
+          </span>
+          <span class="viewer-toggle__text">Dimension</span>
+        </label>
+      </div>
       <aside class="panel panel--left" data-panel>
         <div class="panel__tabs" role="tablist">
           <button

--- a/index.html
+++ b/index.html
@@ -103,6 +103,94 @@
               </div>
             </details>
             <details class="material-section" open>
+              <summary class="material-section__summary">Opacity</summary>
+              <div class="material-section__content">
+                <div class="material-mode" role="radiogroup">
+                  <label class="material-mode__option">
+                    <input type="radio" name="opacity-mode" value="slider" data-opacity-mode />
+                    <span>Slider</span>
+                  </label>
+                  <label class="material-mode__option">
+                    <input type="radio" name="opacity-mode" value="texture" data-opacity-mode />
+                    <span>Texture</span>
+                  </label>
+                  <label class="material-mode__option">
+                    <input type="radio" name="opacity-mode" value="color-alpha" data-opacity-mode />
+                    <span>Color Alpha</span>
+                  </label>
+                </div>
+                <div class="material-opacity material-opacity--slider" data-opacity-slider>
+                  <div class="texture-upload texture-upload--readonly" data-opacity-slider-target>
+                    <img
+                      class="texture-upload__image"
+                      data-opacity-slider-image
+                      alt="Opacity value preview"
+                      width="100"
+                      height="100"
+                    />
+                    <div class="texture-upload__label">Value</div>
+                  </div>
+                  <div class="material-slider material-slider--stacked">
+                    <label class="material-slider__label" for="opacity-slider">Opacity</label>
+                    <input
+                      id="opacity-slider"
+                      type="range"
+                      min="0"
+                      max="1"
+                      step="0.01"
+                      value="1"
+                      class="material-slider__input"
+                      data-opacity-slider-input
+                    />
+                    <input
+                      type="number"
+                      min="0"
+                      max="1"
+                      step="0.01"
+                      value="1.00"
+                      class="material-slider__value"
+                      data-opacity-slider-number
+                      aria-label="Opacity value"
+                    />
+                  </div>
+                </div>
+                <div class="material-opacity material-opacity--texture is-hidden" data-opacity-texture>
+                  <div class="texture-upload" data-opacity-texture-target>
+                    <img
+                      class="texture-upload__image"
+                      data-opacity-texture-image
+                      alt="Opacity texture preview"
+                      width="100"
+                      height="100"
+                    />
+                    <button
+                      type="button"
+                      class="texture-upload__remove"
+                      data-opacity-texture-remove
+                      aria-label="Remove opacity texture"
+                    >
+                      ×
+                    </button>
+                    <div class="texture-upload__label">Upload</div>
+                    <input class="hidden-input" type="file" accept="image/*" data-opacity-texture-input />
+                  </div>
+                </div>
+                <div class="material-opacity material-opacity--color is-hidden" data-opacity-color>
+                  <div class="texture-upload texture-upload--readonly" data-opacity-color-target>
+                    <img
+                      class="texture-upload__image"
+                      data-opacity-color-image
+                      alt="Base color alpha preview"
+                      width="100"
+                      height="100"
+                    />
+                    <div class="texture-upload__label">Color Alpha</div>
+                  </div>
+                  <p class="material-opacity__note">Uses the base color texture alpha channel.</p>
+                </div>
+              </div>
+            </details>
+            <details class="material-section" open>
               <summary class="material-section__summary">Normal Map</summary>
               <div class="material-section__content">
                 <div class="texture-upload" data-normal-texture-target>

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
                   </label>
                   <label class="material-mode__option">
                     <input type="radio" name="opacity-mode" value="color-alpha" data-opacity-mode />
-                    <span>Color Alpha</span>
+                    <span>Alpha</span>
                   </label>
                 </div>
                 <div class="material-opacity material-opacity--slider material-control" data-opacity-slider>
@@ -184,7 +184,7 @@
                       width="100"
                       height="100"
                     />
-                    <div class="texture-upload__label">Color Alpha</div>
+                      <div class="texture-upload__label">Alpha</div>
                   </div>
                   <p class="material-opacity__note">Uses the base color texture alpha channel.</p>
                 </div>
@@ -245,7 +245,7 @@
                 <div class="material-mode" role="radiogroup">
                   <label class="material-mode__option">
                     <input type="radio" name="orm-mode" value="packed" data-orm-mode />
-                    <span>ORM Texture</span>
+                    <span>ORM</span>
                   </label>
                   <label class="material-mode__option">
                     <input type="radio" name="orm-mode" value="separate" data-orm-mode />

--- a/index.html
+++ b/index.html
@@ -60,11 +60,11 @@
                 <div class="material-mode" role="radiogroup">
                   <label class="material-mode__option">
                     <input type="radio" name="color-mode" value="color" data-color-mode />
-                    <span>Цвет</span>
+                    <span>Color</span>
                   </label>
                   <label class="material-mode__option">
                     <input type="radio" name="color-mode" value="texture" data-color-mode />
-                    <span>Текстура</span>
+                    <span>Texture</span>
                   </label>
                 </div>
                 <div class="material-color-picker" data-color-picker>

--- a/index.html
+++ b/index.html
@@ -69,6 +69,7 @@
                 </div>
                 <div class="material-color-picker" data-color-picker>
                   <label class="material-field">
+                    <span class="material-field__preview" data-color-preview aria-hidden="true"></span>
                     <input
                       type="color"
                       class="material-field__input"

--- a/index.html
+++ b/index.html
@@ -47,13 +47,37 @@
           data-panel-section="info"
         >
           <div class="info-panel" data-info-panel>
-            <div class="info-panel__group info-panel__group--language">
+            <div class="info-panel__group">
               <label class="info-field">
-                <span class="info-field__label" data-i18n-key="language.label">Language</span>
-                <select class="info-field__input" data-info-language>
-                  <option value="en">English</option>
-                  <option value="ru">Русский</option>
-                </select>
+                <span class="info-field__label" data-i18n-key="name.label">Name</span>
+                <input
+                  type="text"
+                  class="info-field__input"
+                  data-info-name
+                  data-i18n-placeholder="name.placeholder"
+                />
+              </label>
+            </div>
+            <div class="info-panel__group">
+              <label class="info-field">
+                <span class="info-field__label" data-i18n-key="description.label">Description</span>
+                <textarea
+                  class="info-field__input info-field__input--multiline"
+                  rows="4"
+                  data-info-description
+                  data-i18n-placeholder="description.placeholder"
+                ></textarea>
+              </label>
+            </div>
+            <div class="info-panel__group">
+              <label class="info-field">
+                <span class="info-field__label" data-i18n-key="tags.label">Tags</span>
+                <input
+                  type="text"
+                  class="info-field__input"
+                  data-info-tags
+                  data-i18n-placeholder="tags.placeholder"
+                />
               </label>
             </div>
             <div class="info-panel__group">
@@ -102,7 +126,7 @@
                 />
               </label>
             </div>
-            <div class="info-panel__group info-panel__group--split">
+            <div class="info-panel__group">
               <label class="info-field">
                 <span class="info-field__label" data-i18n-key="brand.label">Brand</span>
                 <input
@@ -112,6 +136,8 @@
                   data-i18n-placeholder="brand.placeholder"
                 />
               </label>
+            </div>
+            <div class="info-panel__group">
               <label class="info-field">
                 <span class="info-field__label">
                   <span data-i18n-key="category.label">Category</span>
@@ -130,34 +156,13 @@
                 </select>
               </label>
             </div>
-            <div class="info-panel__group info-panel__group--split" data-info-subcategory-group>
+            <div class="info-panel__group" data-info-subcategory-group>
               <label class="info-field">
                 <span class="info-field__label" data-i18n-key="subcategory.label">Subcategory</span>
                 <select class="info-field__input" data-info-subcategory>
                   <option value="" data-i18n-key="subcategory.placeholder">Select subcategory</option>
                 </select>
               </label>
-              <div class="info-panel__preview" data-info-category-preview>
-                <img alt="" data-info-category-image width="100" height="100" />
-                <span class="info-panel__preview-label" data-i18n-key="subcategory.previewLabel">Preview</span>
-              </div>
-            </div>
-            <div class="info-panel__group">
-              <div class="info-field info-field--stacked">
-                <div class="info-field__label info-field__label--split">
-                  <span data-i18n-key="color.label">Color miniature</span>
-                  <button
-                    type="button"
-                    class="info-field__help"
-                    aria-label="Color miniature description"
-                    data-tooltip-button
-                    data-i18n-tooltip="color.help"
-                  >
-                    ?
-                  </button>
-                </div>
-                <div class="info-panel__color-grid" data-info-color-grid></div>
-              </div>
             </div>
             <div class="info-panel__group">
               <label class="info-field">

--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
             </div>
             <div class="info-panel__group">
               <label class="info-field">
-                <span class="info-field__label">
+                <span class="info-field__label info-field__label--with-help">
                   <span data-i18n-key="category.label">Category</span>
                   <button
                     type="button"
@@ -172,7 +172,7 @@
             </div>
             <div class="info-panel__group">
               <label class="info-field">
-                <span class="info-field__label">
+                <span class="info-field__label info-field__label--with-help">
                   <span data-i18n-key="visibility.label">Visibility</span>
                   <button
                     type="button"

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
             </div>
             <div class="info-panel__group">
               <label class="info-field">
-                <span class="info-field__label">
+                <span class="info-field__label material-section__label">
                   <span data-i18n-key="placement.label">Placement type</span>
                   <button
                     type="button"
@@ -107,7 +107,7 @@
             </div>
             <div class="info-panel__group">
               <label class="info-field">
-                <span class="info-field__label">
+                <span class="info-field__label material-section__label">
                   <span data-i18n-key="destination.label">Destination Url</span>
                   <button
                     type="button"
@@ -141,7 +141,7 @@
             </div>
             <div class="info-panel__group">
               <label class="info-field">
-                <span class="info-field__label info-field__label--with-help">
+                <span class="info-field__label material-section__label">
                   <span data-i18n-key="category.label">Category</span>
                   <button
                     type="button"
@@ -172,7 +172,7 @@
             </div>
             <div class="info-panel__group">
               <label class="info-field">
-                <span class="info-field__label info-field__label--with-help">
+                <span class="info-field__label material-section__label">
                   <span data-i18n-key="visibility.label">Visibility</span>
                   <button
                     type="button"

--- a/index.html
+++ b/index.html
@@ -75,6 +75,7 @@
                       data-color-input
                       aria-label="Base color"
                     />
+                    <span class="material-field__hover-label" aria-hidden="true">Pick</span>
                   </label>
                 </div>
                 <div class="material-texture-picker is-hidden" data-color-texture>

--- a/src/core/importManager.js
+++ b/src/core/importManager.js
@@ -529,7 +529,8 @@ export class ImportManager {
       meshMaterial.opacity = opacity;
       needsUpdate = true;
     }
-    const shouldBeTransparent = opacity < 1 || Boolean(meshMaterial.alphaMap);
+    const shouldBeTransparent =
+      Boolean(meshMaterial.transparent) || opacity < 1 || Boolean(meshMaterial.alphaMap);
     if (meshMaterial.transparent !== shouldBeTransparent) {
       meshMaterial.transparent = shouldBeTransparent;
       needsUpdate = true;

--- a/src/core/importManager.js
+++ b/src/core/importManager.js
@@ -106,7 +106,8 @@ export class ImportManager {
       const li = this.panel.createMeshRow({
         name: mesh.name,
         onClick: (event) => {
-          this.selectionManager.selectFromList(mesh.uuid, event.shiftKey);
+          const additive = event.ctrlKey || event.metaKey;
+          this.selectionManager.selectFromList(mesh.uuid, additive);
         },
         onHide: () => {
           mesh.visible = !mesh.visible;

--- a/src/core/importManager.js
+++ b/src/core/importManager.js
@@ -121,6 +121,10 @@ export class ImportManager {
       });
       this.selectionManager.registerMesh(mesh, li);
     });
+
+    if (meshes.length > 0) {
+      this.sceneManager.frameMeshes(meshes);
+    }
   }
 
   /**

--- a/src/core/importManager.js
+++ b/src/core/importManager.js
@@ -109,6 +109,9 @@ export class ImportManager {
           const additive = event.ctrlKey || event.metaKey;
           this.selectionManager.selectFromList(mesh.uuid, additive);
         },
+        onDoubleClick: () => {
+          this.sceneManager.focusMesh(mesh);
+        },
         onHide: () => {
           mesh.visible = !mesh.visible;
           return mesh.visible;

--- a/src/core/importManager.js
+++ b/src/core/importManager.js
@@ -53,6 +53,8 @@ const UNSUPPORTED_TEXTURE_PROPS = [
   'anisotropyMap',
 ];
 
+const INITIAL_TRANSFORM_KEY = '__initialTransform';
+
 /**
  * Отвечает за загрузку файлов и добавление новых мешей в сцену и UI.
  */
@@ -90,6 +92,16 @@ export class ImportManager {
     meshes.forEach((mesh) => {
       mesh.visible = true;
       mesh.matrixAutoUpdate = true;
+      if (!mesh.userData) {
+        mesh.userData = {};
+      }
+      if (!mesh.userData[INITIAL_TRANSFORM_KEY]) {
+        mesh.userData[INITIAL_TRANSFORM_KEY] = {
+          position: mesh.position.clone(),
+          rotation: mesh.rotation.clone(),
+          scale: mesh.scale.clone(),
+        };
+      }
       this.sceneManager.addMesh(mesh);
       const li = this.panel.createMeshRow({
         name: mesh.name,

--- a/src/core/importManager.js
+++ b/src/core/importManager.js
@@ -550,6 +550,11 @@ export class ImportManager {
       meshMaterial.blending = desiredBlending;
       needsUpdate = true;
     }
+    const desiredDepthWrite = hasAlphaMask ? true : !shouldBeTransparent;
+    if (meshMaterial.depthWrite !== desiredDepthWrite) {
+      meshMaterial.depthWrite = desiredDepthWrite;
+      needsUpdate = true;
+    }
     const desiredAlphaMode = hasAlphaMask ? 'MASK' : shouldBeTransparent ? 'BLEND' : 'OPAQUE';
     meshMaterial.userData = meshMaterial.userData ?? {};
     if (meshMaterial.userData.alphaMode !== desiredAlphaMode) {

--- a/src/core/importManager.js
+++ b/src/core/importManager.js
@@ -7,6 +7,8 @@ import {
   BufferGeometry,
   Matrix4,
   MeshStandardMaterial,
+  NoBlending,
+  NormalBlending,
   Quaternion,
   SRGBColorSpace,
   Vector3,
@@ -530,6 +532,11 @@ export class ImportManager {
     const shouldBeTransparent = opacity < 1 || Boolean(meshMaterial.alphaMap);
     if (meshMaterial.transparent !== shouldBeTransparent) {
       meshMaterial.transparent = shouldBeTransparent;
+      needsUpdate = true;
+    }
+    const desiredBlending = shouldBeTransparent ? NormalBlending : NoBlending;
+    if (meshMaterial.blending !== desiredBlending) {
+      meshMaterial.blending = desiredBlending;
       needsUpdate = true;
     }
 

--- a/src/core/importManager.js
+++ b/src/core/importManager.js
@@ -529,8 +529,18 @@ export class ImportManager {
       meshMaterial.opacity = opacity;
       needsUpdate = true;
     }
+    const alphaTest = clamp(
+      typeof meshMaterial.alphaTest === 'number' ? meshMaterial.alphaTest : 0,
+      0,
+      1,
+    );
+    const hasAlphaMask = alphaTest > 0;
+    if (meshMaterial.alphaTest !== alphaTest) {
+      meshMaterial.alphaTest = alphaTest;
+      needsUpdate = true;
+    }
     const shouldBeTransparent =
-      Boolean(meshMaterial.transparent) || opacity < 1 || Boolean(meshMaterial.alphaMap);
+      !hasAlphaMask && (Boolean(meshMaterial.transparent) || opacity < 1 || Boolean(meshMaterial.alphaMap));
     if (meshMaterial.transparent !== shouldBeTransparent) {
       meshMaterial.transparent = shouldBeTransparent;
       needsUpdate = true;
@@ -538,6 +548,16 @@ export class ImportManager {
     const desiredBlending = shouldBeTransparent ? NormalBlending : NoBlending;
     if (meshMaterial.blending !== desiredBlending) {
       meshMaterial.blending = desiredBlending;
+      needsUpdate = true;
+    }
+    const desiredAlphaMode = hasAlphaMask ? 'MASK' : shouldBeTransparent ? 'BLEND' : 'OPAQUE';
+    meshMaterial.userData = meshMaterial.userData ?? {};
+    if (meshMaterial.userData.alphaMode !== desiredAlphaMode) {
+      meshMaterial.userData.alphaMode = desiredAlphaMode;
+      needsUpdate = true;
+    }
+    if (!hasAlphaMask && meshMaterial.alphaTest !== 0) {
+      meshMaterial.alphaTest = 0;
       needsUpdate = true;
     }
 

--- a/src/core/sceneManager.js
+++ b/src/core/sceneManager.js
@@ -1,12 +1,23 @@
 import {
   ACESFilmicToneMapping,
+  Box3,
+  BufferGeometry,
+  CanvasTexture,
   Color,
+  Float32BufferAttribute,
+  Group,
+  Line,
+  LineDashedMaterial,
+  MathUtils,
   PerspectiveCamera,
   PMREMGenerator,
   Raycaster,
   Scene,
+  Sprite,
+  SpriteMaterial,
   SRGBColorSpace,
   Vector2,
+  Vector3,
   WebGLRenderer,
 } from 'three';
 import { OrbitControls } from 'OrbitControls';
@@ -47,6 +58,57 @@ export class SceneManager {
     this.pointer = new Vector2();
 
     this._animationFrame = null;
+
+    /** @type {Set<import('three').Object3D>} */
+    this.meshRegistry = new Set();
+
+    this.dimensionState = {
+      enabled: false,
+      useSelection: false,
+      targets: [],
+      group: new Group(),
+    };
+
+    this.dimensionState.group.visible = false;
+    this.dimensionMaterial = new LineDashedMaterial({
+      color: 0x2563eb,
+      dashSize: 0.25,
+      gapSize: 0.16,
+      linewidth: 1,
+    });
+    this.dimensionMaterial.transparent = true;
+    this.dimensionMaterial.opacity = 0.9;
+    this.dimensionMaterial.depthTest = false;
+    this.dimensionMaterial.depthWrite = false;
+
+    this.dimensionLines = {
+      width: new Line(new BufferGeometry(), this.dimensionMaterial.clone()),
+      depth: new Line(new BufferGeometry(), this.dimensionMaterial.clone()),
+      height: new Line(new BufferGeometry(), this.dimensionMaterial.clone()),
+    };
+
+    Object.values(this.dimensionLines).forEach((line) => {
+      const material = /** @type {LineDashedMaterial} */ (line.material);
+      material.transparent = true;
+      material.opacity = 0.9;
+      material.depthTest = false;
+      material.depthWrite = false;
+      line.renderOrder = 3;
+      this.dimensionState.group.add(line);
+    });
+
+    this.dimensionLabels = {
+      width: this.#createDimensionLabel(),
+      depth: this.#createDimensionLabel(),
+      height: this.#createDimensionLabel(),
+    };
+
+    Object.values(this.dimensionLabels).forEach((label) => {
+      label.renderOrder = 4;
+      this.dimensionState.group.add(label);
+    });
+
+    this.scene.add(this.dimensionState.group);
   }
 
   /**
@@ -141,6 +203,11 @@ export class SceneManager {
    */
   addMesh(mesh) {
     this.scene.add(mesh);
+    this.meshRegistry.add(mesh);
+    if (this.dimensionState.enabled && !this.dimensionState.useSelection) {
+      this.dimensionState.targets = Array.from(this.meshRegistry);
+      this.#refreshDimensionOverlay();
+    }
   }
 
   /**
@@ -149,6 +216,17 @@ export class SceneManager {
    */
   removeMesh(mesh) {
     this.scene.remove(mesh);
+    this.meshRegistry.delete(mesh);
+    if (this.dimensionState.enabled) {
+      if (this.dimensionState.useSelection) {
+        this.dimensionState.targets = this.dimensionState.targets.filter(
+          (target) => target !== mesh,
+        );
+      } else {
+        this.dimensionState.targets = Array.from(this.meshRegistry);
+      }
+      this.#refreshDimensionOverlay();
+    }
   }
 
   /**
@@ -158,5 +236,300 @@ export class SceneManager {
     window.cancelAnimationFrame(this._animationFrame);
     this.controls.dispose();
     this.renderer.dispose();
+  }
+
+  /**
+   * Включает или выключает отображение размеров модели.
+   * @param {boolean} enabled
+   */
+  setDimensionEnabled(enabled) {
+    this.dimensionState.enabled = enabled;
+    if (!enabled) {
+      this.dimensionState.group.visible = false;
+      return;
+    }
+    this.#refreshDimensionOverlay();
+  }
+
+  /**
+   * Обновляет набор мешей, для которых рисуются размеры.
+   * @param {Set<import('three').Object3D>} selectedMeshes
+   */
+  updateDimensionTargets(selectedMeshes) {
+    const useSelection = selectedMeshes && selectedMeshes.size > 0;
+    this.dimensionState.useSelection = useSelection;
+    this.dimensionState.targets = useSelection
+      ? Array.from(selectedMeshes)
+      : Array.from(this.meshRegistry);
+    if (this.dimensionState.enabled) {
+      this.#refreshDimensionOverlay();
+    }
+  }
+
+  /**
+   * Перемещает камеру так, чтобы выбранные меши целиком попадали в кадр.
+   * @param {import('three').Object3D[]} meshes
+   */
+  frameMeshes(meshes) {
+    if (!meshes || meshes.length === 0) {
+      return;
+    }
+    const box = new Box3();
+    const tempBox = new Box3();
+    let hasValid = false;
+    meshes.forEach((mesh) => {
+      if (!mesh) {
+        return;
+      }
+      mesh.updateMatrixWorld(true);
+      tempBox.makeEmpty();
+      tempBox.expandByObject(mesh);
+      if (!tempBox.isEmpty()) {
+        box.union(tempBox);
+        hasValid = true;
+      }
+    });
+    if (!hasValid || box.isEmpty()) {
+      return;
+    }
+
+    const size = box.getSize(new Vector3());
+    const center = box.getCenter(new Vector3());
+    const maxDim = Math.max(size.x, size.y, size.z);
+    if (!Number.isFinite(maxDim) || maxDim === 0) {
+      return;
+    }
+
+    const fov = MathUtils.degToRad(this.camera.fov);
+    const distance = maxDim / (2 * Math.tan(fov / 2));
+    const offsetDistance = distance * 1.6;
+    const direction = new Vector3(1, 1, 1).normalize();
+    const newPosition = center.clone().add(direction.multiplyScalar(offsetDistance));
+
+    this.camera.position.copy(newPosition);
+    this.controls.target.copy(center);
+    this.controls.update();
+
+    const near = Math.max(offsetDistance / 50, 0.1);
+    const far = Math.max(offsetDistance * 10, near + 10);
+    this.camera.near = near;
+    this.camera.far = far;
+    this.camera.updateProjectionMatrix();
+  }
+
+  /**
+   * Форматирует длину в сантиметрах.
+   * @param {number} length
+   * @returns {string}
+   */
+  #formatCentimeters(length) {
+    if (!Number.isFinite(length)) {
+      return '0 cm';
+    }
+    const centimeters = length * 100;
+    const value =
+      Math.abs(centimeters) >= 10
+        ? Math.round(centimeters)
+        : Math.round(centimeters * 10) / 10;
+    return `${value.toLocaleString('en-US')} cm`;
+  }
+
+  /**
+   * Обновляет отображение размеров.
+   */
+  #refreshDimensionOverlay() {
+    if (!this.dimensionState.enabled) {
+      this.dimensionState.group.visible = false;
+      return;
+    }
+    const targets = this.dimensionState.targets;
+    if (!targets || targets.length === 0) {
+      this.dimensionState.group.visible = false;
+      return;
+    }
+
+    const box = new Box3();
+    const tempBox = new Box3();
+    let hasValid = false;
+    targets.forEach((mesh) => {
+      if (!mesh) {
+        return;
+      }
+      mesh.updateMatrixWorld(true);
+      tempBox.makeEmpty();
+      tempBox.expandByObject(mesh);
+      if (!tempBox.isEmpty()) {
+        box.union(tempBox);
+        hasValid = true;
+      }
+    });
+
+    if (!hasValid || box.isEmpty()) {
+      this.dimensionState.group.visible = false;
+      return;
+    }
+
+    const size = box.getSize(new Vector3());
+    const maxDim = Math.max(size.x, size.y, size.z);
+    if (!Number.isFinite(maxDim) || maxDim === 0) {
+      this.dimensionState.group.visible = false;
+      return;
+    }
+
+    const padding = Math.max(maxDim * 0.08, 0.1);
+    const labelOffset = Math.max(maxDim * 0.05, 0.08);
+    const dashSize = Math.max(maxDim * 0.12, 0.12);
+    const gapSize = dashSize * 0.55;
+
+    const min = box.min.clone();
+    const max = box.max.clone();
+
+    const widthStart = new Vector3(min.x, min.y, max.z + padding);
+    const widthEnd = new Vector3(max.x, min.y, max.z + padding);
+
+    const depthStart = new Vector3(max.x + padding, min.y, min.z);
+    const depthEnd = new Vector3(max.x + padding, min.y, max.z);
+
+    const heightStart = new Vector3(max.x, min.y - padding, max.z + padding);
+    const heightEnd = new Vector3(max.x, max.y + padding, max.z + padding);
+
+    this.#updateDimensionLine(this.dimensionLines.width, widthStart, widthEnd, dashSize, gapSize);
+    this.#updateDimensionLine(this.dimensionLines.depth, depthStart, depthEnd, dashSize, gapSize);
+    this.#updateDimensionLine(this.dimensionLines.height, heightStart, heightEnd, dashSize, gapSize);
+
+    const baseScale = Math.max(maxDim * 0.25, 0.45);
+
+    const widthLabel = this.dimensionLabels.width;
+    widthLabel.position.copy(widthStart.clone().lerp(widthEnd, 0.5));
+    widthLabel.position.y += labelOffset;
+    this.#updateDimensionLabel(widthLabel, this.#formatCentimeters(size.x), baseScale);
+
+    const depthLabel = this.dimensionLabels.depth;
+    depthLabel.position.copy(depthStart.clone().lerp(depthEnd, 0.5));
+    depthLabel.position.x += labelOffset;
+    this.#updateDimensionLabel(depthLabel, this.#formatCentimeters(size.z), baseScale);
+
+    const heightLabel = this.dimensionLabels.height;
+    heightLabel.position.copy(heightStart.clone().lerp(heightEnd, 0.5));
+    heightLabel.position.z += labelOffset;
+    this.#updateDimensionLabel(heightLabel, this.#formatCentimeters(size.y), baseScale);
+
+    this.dimensionState.group.visible = true;
+  }
+
+  /**
+   * Создаёт спрайт для отображения размера.
+   * @returns {Sprite}
+   */
+  #createDimensionLabel() {
+    const canvas = document.createElement('canvas');
+    canvas.width = 256;
+    canvas.height = 128;
+    const texture = new CanvasTexture(canvas);
+    texture.colorSpace = SRGBColorSpace;
+    texture.needsUpdate = true;
+    const material = new SpriteMaterial({
+      map: texture,
+      transparent: true,
+      depthTest: false,
+      depthWrite: false,
+    });
+    return new Sprite(material);
+  }
+
+  /**
+   * Обновляет геометрию линий размеров.
+   * @param {Line} line
+   * @param {Vector3} start
+   * @param {Vector3} end
+   * @param {number} dashSize
+   * @param {number} gapSize
+   */
+  #updateDimensionLine(line, start, end, dashSize, gapSize) {
+    const positions = new Float32Array([
+      start.x,
+      start.y,
+      start.z,
+      end.x,
+      end.y,
+      end.z,
+    ]);
+    line.geometry.setAttribute('position', new Float32BufferAttribute(positions, 3));
+    line.geometry.computeBoundingSphere();
+    line.computeLineDistances();
+    const material = /** @type {LineDashedMaterial} */ (line.material);
+    material.dashSize = dashSize;
+    material.gapSize = gapSize;
+    material.needsUpdate = true;
+  }
+
+  /**
+   * Перерисовывает текст ярлыка размера.
+   * @param {Sprite} sprite
+   * @param {string} text
+   * @param {number} baseScale
+   */
+  #updateDimensionLabel(sprite, text, baseScale) {
+    const canvas = document.createElement('canvas');
+    canvas.width = 256;
+    canvas.height = 128;
+    const context = canvas.getContext('2d');
+    if (!context) {
+      return;
+    }
+
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    const radius = 40;
+    const paddingX = 12;
+    const paddingY = 16;
+
+    context.fillStyle = 'rgba(15, 23, 42, 0.92)';
+    context.beginPath();
+    context.moveTo(paddingX + radius, paddingY);
+    context.lineTo(canvas.width - paddingX - radius, paddingY);
+    context.quadraticCurveTo(
+      canvas.width - paddingX,
+      paddingY,
+      canvas.width - paddingX,
+      paddingY + radius,
+    );
+    context.lineTo(canvas.width - paddingX, canvas.height - paddingY - radius);
+    context.quadraticCurveTo(
+      canvas.width - paddingX,
+      canvas.height - paddingY,
+      canvas.width - paddingX - radius,
+      canvas.height - paddingY,
+    );
+    context.lineTo(paddingX + radius, canvas.height - paddingY);
+    context.quadraticCurveTo(
+      paddingX,
+      canvas.height - paddingY,
+      paddingX,
+      canvas.height - paddingY - radius,
+    );
+    context.lineTo(paddingX, paddingY + radius);
+    context.quadraticCurveTo(paddingX, paddingY, paddingX + radius, paddingY);
+    context.closePath();
+    context.fill();
+
+    context.fillStyle = '#ffffff';
+    context.font = '700 44px "Inter", sans-serif';
+    context.textAlign = 'center';
+    context.textBaseline = 'middle';
+    context.fillText(text, canvas.width / 2, canvas.height / 2);
+
+    const texture = new CanvasTexture(canvas);
+    texture.colorSpace = SRGBColorSpace;
+    texture.needsUpdate = true;
+
+    const material = /** @type {SpriteMaterial} */ (sprite.material);
+    if (material.map) {
+      material.map.dispose();
+    }
+    material.map = texture;
+    material.needsUpdate = true;
+
+    const aspect = canvas.height / canvas.width;
+    sprite.scale.set(baseScale, baseScale * aspect, 1);
   }
 }

--- a/src/core/sceneManager.js
+++ b/src/core/sceneManager.js
@@ -31,7 +31,7 @@ export class SceneManager {
     const near = 0.1;
     const far = 1000;
     this.camera = new PerspectiveCamera(fov, aspect, near, far);
-    this.camera.position.set(3, 3, 6);
+    this.camera.position.set(3, 3.5, 6);
 
     this.renderer = new WebGLRenderer({ canvas: this.canvas, antialias: true });
     this.renderer.setSize(window.innerWidth, window.innerHeight);

--- a/src/core/selectionManager.js
+++ b/src/core/selectionManager.js
@@ -81,16 +81,16 @@ export class SelectionManager extends EventTarget {
   /**
    * Обработка клика по строке списка.
    * @param {string} uuid
-   * @param {boolean} withShift
+   * @param {boolean} withCtrl
    */
-  selectFromList(uuid, withShift) {
+  selectFromList(uuid, withCtrl) {
     if (!this.meshMap.has(uuid)) {
       return;
     }
 
     const mesh = this.meshMap.get(uuid)?.mesh ?? null;
     if (mesh) {
-      this.#selectMesh(mesh, withShift);
+      this.#selectMesh(mesh, withCtrl);
     }
   }
 

--- a/src/core/transformManager.js
+++ b/src/core/transformManager.js
@@ -93,6 +93,9 @@ export class TransformManager extends EventTarget {
       }
       this.transformControls.visible = hasSelection;
     }
+    if (this.currentSelection.size > 0) {
+      this.updateAnchorFromSelection(this.currentSelection);
+    }
     if (previousMode !== mode) {
       this.dispatchEvent(new CustomEvent('modechange', { detail: { mode } }));
     }

--- a/src/core/transformManager.js
+++ b/src/core/transformManager.js
@@ -75,9 +75,7 @@ export class TransformManager extends EventTarget {
    * @param {'none' | 'translate' | 'rotate' | 'scale'} mode
    */
   setMode(mode) {
-    if (this.mode === mode) {
-      return;
-    }
+    const previousMode = this.mode;
     this.mode = mode;
     if (mode === 'none') {
       this.transformControls.detach();
@@ -87,12 +85,17 @@ export class TransformManager extends EventTarget {
       if (controlsMode) {
         this.transformControls.setMode(controlsMode);
       }
-      this.transformControls.visible = this.currentSelection.size > 0;
-      if (this.currentSelection.size > 0 && this.transformControls.object !== this.anchor) {
+      const hasSelection = this.currentSelection.size > 0;
+      if (hasSelection) {
         this.transformControls.attach(this.anchor);
+      } else {
+        this.transformControls.detach();
       }
+      this.transformControls.visible = hasSelection;
     }
-    this.dispatchEvent(new CustomEvent('modechange', { detail: { mode } }));
+    if (previousMode !== mode) {
+      this.dispatchEvent(new CustomEvent('modechange', { detail: { mode } }));
+    }
   }
 
   /**
@@ -144,9 +147,11 @@ export class TransformManager extends EventTarget {
     }
 
     this.anchor.updateMatrixWorld(true);
-    if (this.mode !== 'none') {
+    const shouldShow = this.mode !== 'none' && this.currentSelection.size > 0;
+    if (shouldShow) {
       this.transformControls.attach(this.anchor);
       this.transformControls.visible = true;
+      this.transformControls.updateMatrixWorld(true);
     } else {
       this.transformControls.detach();
       this.transformControls.visible = false;

--- a/src/core/undoManager.js
+++ b/src/core/undoManager.js
@@ -1,0 +1,93 @@
+/**
+ * Stores transform snapshots and applies them on undo requests.
+ */
+export class UndoManager {
+  /**
+   * @param {number} [limit]
+   */
+  constructor(limit = 100) {
+    this.limit = limit;
+    /** @type {Array<Array<{ mesh: import('three').Object3D; position: import('three').Vector3; quaternion: import('three').Quaternion; scale: import('three').Vector3 }>>> */
+    this.stack = [];
+  }
+
+  /**
+   * Captures the current transform of each mesh in the iterable.
+   * @param {Iterable<import('three').Object3D>} meshes
+   * @returns {Array<{ mesh: import('three').Object3D; position: import('three').Vector3; quaternion: import('three').Quaternion; scale: import('three').Vector3 }>}
+   */
+  captureSnapshot(meshes) {
+    const snapshot = [];
+    const seen = new Set();
+    for (const mesh of meshes) {
+      if (!mesh || seen.has(mesh.uuid)) {
+        continue;
+      }
+      seen.add(mesh.uuid);
+      snapshot.push({
+        mesh,
+        position: mesh.position.clone(),
+        quaternion: mesh.quaternion.clone(),
+        scale: mesh.scale.clone(),
+      });
+    }
+    return snapshot;
+  }
+
+  /**
+   * Saves the snapshot if at least one mesh has changed since capture.
+   * @param {Array<{ mesh: import('three').Object3D; position: import('three').Vector3; quaternion: import('three').Quaternion; scale: import('three').Vector3 }>} snapshot
+   */
+  commitSnapshot(snapshot) {
+    if (!snapshot || snapshot.length === 0) {
+      return;
+    }
+    const changed = snapshot.some(({ mesh, position, quaternion, scale }) => {
+      if (!mesh) {
+        return false;
+      }
+      return (
+        !mesh.position.equals(position) ||
+        !mesh.quaternion.equals(quaternion) ||
+        !mesh.scale.equals(scale)
+      );
+    });
+    if (!changed) {
+      return;
+    }
+    if (this.stack.length >= this.limit) {
+      this.stack.shift();
+    }
+    this.stack.push(snapshot);
+  }
+
+  /**
+   * Reverts the last committed snapshot.
+   * @returns {{ meshes: Set<import('three').Object3D> } | null}
+   */
+  undo() {
+    if (this.stack.length === 0) {
+      return null;
+    }
+    const snapshot = this.stack.pop();
+    const meshes = new Set();
+    snapshot.forEach(({ mesh, position, quaternion, scale }) => {
+      if (!mesh) {
+        return;
+      }
+      mesh.position.copy(position);
+      mesh.quaternion.copy(quaternion);
+      mesh.scale.copy(scale);
+      mesh.updateMatrixWorld(true);
+      meshes.add(mesh);
+    });
+    return { meshes };
+  }
+
+  /**
+   * Clears all stored actions.
+   */
+  clear() {
+    this.stack.length = 0;
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -5,13 +5,15 @@ import { TransformManager } from './core/transformManager.js';
 import { Inspector } from './ui/inspector.js';
 import { Panel } from './ui/panel.js';
 import { Toolbar } from './ui/toolbar.js';
+import { MaterialPanel } from './ui/materialPanel.js';
 
 const canvas = /** @type {HTMLCanvasElement | null} */ (document.getElementById('scene'));
 const panelElement = /** @type {HTMLElement | null} */ (document.querySelector('[data-panel]'));
 const toolbarElement = /** @type {HTMLElement | null} */ (document.querySelector('[data-toolbar]'));
 const inspectorElement = /** @type {HTMLElement | null} */ (document.querySelector('[data-inspector]'));
+const materialPanelElement = /** @type {HTMLElement | null} */ (document.querySelector('[data-material-panel]'));
 
-if (!canvas || !panelElement || !toolbarElement || !inspectorElement) {
+if (!canvas || !panelElement || !toolbarElement || !inspectorElement || !materialPanelElement) {
   throw new Error('UI elements are missing in the document.');
 }
 
@@ -22,6 +24,9 @@ const panel = new Panel(panelElement);
 const toolbar = new Toolbar(toolbarElement);
 const inspector = new Inspector(inspectorElement, transformManager, selectionManager);
 const importManager = new ImportManager(sceneManager, selectionManager, panel);
+const materialPanel = new MaterialPanel(materialPanelElement);
+
+materialPanel.update(selectionManager.getSelectionState().selectedMeshes);
 
 let pointerDownPosition = null;
 let transformRecentlyActive = false;
@@ -54,6 +59,7 @@ selectionManager.addEventListener('selectionchange', (event) => {
   const { selectedMeshes } = event.detail;
   transformManager.updateAnchorFromSelection(selectedMeshes);
   inspector.update(selectedMeshes, transformManager.mode);
+  materialPanel.update(selectedMeshes);
 });
 
 transformManager.addEventListener('transformchange', () => {

--- a/src/main.js
+++ b/src/main.js
@@ -45,13 +45,13 @@ const materialPanel = new MaterialPanel(materialPanelElement);
 const infoPanel = new InfoPanel(infoPanelElement);
 
 materialPanel.update(selectionManager.getSelectionState().selectedMeshes);
-sceneManager.updateDimensionTargets(selectionManager.getSelectionState().selectedMeshes);
+sceneManager.updateDimensionTargets();
 
 sceneManager.setDimensionEnabled(dimensionToggle.checked);
 
 dimensionToggle.addEventListener('change', () => {
   sceneManager.setDimensionEnabled(dimensionToggle.checked);
-  sceneManager.updateDimensionTargets(selectionManager.getSelectionState().selectedMeshes);
+  sceneManager.updateDimensionTargets();
 });
 
 let pointerDownPosition = null;
@@ -76,7 +76,7 @@ toolbar.setActiveMode('none');
 panel.bindImport(async (file) => {
   try {
     await importManager.importModel(file);
-    sceneManager.updateDimensionTargets(selectionManager.getSelectionState().selectedMeshes);
+    sceneManager.updateDimensionTargets();
   } catch (error) {
     console.error('Error importing model', error);
   }
@@ -91,7 +91,7 @@ selectionManager.addEventListener('selectionchange', (event) => {
   transformManager.updateAnchorFromSelection(selectedMeshes);
   inspector.update(selectedMeshes, transformManager.mode);
   materialPanel.update(selectedMeshes);
-  sceneManager.updateDimensionTargets(selectedMeshes);
+  sceneManager.updateDimensionTargets();
 });
 
 transformManager.addEventListener('transformchange', () => {

--- a/src/main.js
+++ b/src/main.js
@@ -55,6 +55,10 @@ panel.bindImport(async (file) => {
   }
 });
 
+panel.bindSelectAll(() => {
+  selectionManager.selectAll();
+});
+
 selectionManager.addEventListener('selectionchange', (event) => {
   const { selectedMeshes } = event.detail;
   transformManager.updateAnchorFromSelection(selectedMeshes);

--- a/src/main.js
+++ b/src/main.js
@@ -116,5 +116,6 @@ canvas.addEventListener('pointerup', (event) => {
       break;
     }
   }
-  selectionManager.selectFromScene(targetMesh, event.shiftKey);
+  const additive = event.ctrlKey || event.metaKey;
+  selectionManager.selectFromScene(targetMesh, additive);
 });

--- a/src/main.js
+++ b/src/main.js
@@ -13,10 +13,23 @@ const canvas = /** @type {HTMLCanvasElement | null} */ (document.getElementById(
 const panelElement = /** @type {HTMLElement | null} */ (document.querySelector('[data-panel]'));
 const toolbarElement = /** @type {HTMLElement | null} */ (document.querySelector('[data-toolbar]'));
 const inspectorElement = /** @type {HTMLElement | null} */ (document.querySelector('[data-inspector]'));
-const materialPanelElement = /** @type {HTMLElement | null} */ (document.querySelector('[data-material-panel]'));
+const materialPanelElement = /** @type {HTMLElement | null} */ (
+  document.querySelector('[data-material-panel]'),
+);
 const infoPanelElement = /** @type {HTMLElement | null} */ (document.querySelector('[data-info-panel]'));
+const dimensionToggle = /** @type {HTMLInputElement | null} */ (
+  document.querySelector('[data-dimension-toggle]'),
+);
 
-if (!canvas || !panelElement || !toolbarElement || !inspectorElement || !materialPanelElement || !infoPanelElement) {
+if (
+  !canvas ||
+  !panelElement ||
+  !toolbarElement ||
+  !inspectorElement ||
+  !materialPanelElement ||
+  !infoPanelElement ||
+  !dimensionToggle
+) {
   throw new Error('UI elements are missing in the document.');
 }
 
@@ -32,6 +45,14 @@ const materialPanel = new MaterialPanel(materialPanelElement);
 const infoPanel = new InfoPanel(infoPanelElement);
 
 materialPanel.update(selectionManager.getSelectionState().selectedMeshes);
+sceneManager.updateDimensionTargets(selectionManager.getSelectionState().selectedMeshes);
+
+sceneManager.setDimensionEnabled(dimensionToggle.checked);
+
+dimensionToggle.addEventListener('change', () => {
+  sceneManager.setDimensionEnabled(dimensionToggle.checked);
+  sceneManager.updateDimensionTargets(selectionManager.getSelectionState().selectedMeshes);
+});
 
 let pointerDownPosition = null;
 let transformRecentlyActive = false;
@@ -55,6 +76,7 @@ toolbar.setActiveMode('none');
 panel.bindImport(async (file) => {
   try {
     await importManager.importModel(file);
+    sceneManager.updateDimensionTargets(selectionManager.getSelectionState().selectedMeshes);
   } catch (error) {
     console.error('Error importing model', error);
   }
@@ -69,6 +91,7 @@ selectionManager.addEventListener('selectionchange', (event) => {
   transformManager.updateAnchorFromSelection(selectedMeshes);
   inspector.update(selectedMeshes, transformManager.mode);
   materialPanel.update(selectedMeshes);
+  sceneManager.updateDimensionTargets(selectedMeshes);
 });
 
 transformManager.addEventListener('transformchange', () => {

--- a/src/main.js
+++ b/src/main.js
@@ -6,14 +6,16 @@ import { Inspector } from './ui/inspector.js';
 import { Panel } from './ui/panel.js';
 import { Toolbar } from './ui/toolbar.js';
 import { MaterialPanel } from './ui/materialPanel.js';
+import { InfoPanel } from './ui/infoPanel.js';
 
 const canvas = /** @type {HTMLCanvasElement | null} */ (document.getElementById('scene'));
 const panelElement = /** @type {HTMLElement | null} */ (document.querySelector('[data-panel]'));
 const toolbarElement = /** @type {HTMLElement | null} */ (document.querySelector('[data-toolbar]'));
 const inspectorElement = /** @type {HTMLElement | null} */ (document.querySelector('[data-inspector]'));
 const materialPanelElement = /** @type {HTMLElement | null} */ (document.querySelector('[data-material-panel]'));
+const infoPanelElement = /** @type {HTMLElement | null} */ (document.querySelector('[data-info-panel]'));
 
-if (!canvas || !panelElement || !toolbarElement || !inspectorElement || !materialPanelElement) {
+if (!canvas || !panelElement || !toolbarElement || !inspectorElement || !materialPanelElement || !infoPanelElement) {
   throw new Error('UI elements are missing in the document.');
 }
 
@@ -25,6 +27,7 @@ const toolbar = new Toolbar(toolbarElement);
 const inspector = new Inspector(inspectorElement, transformManager, selectionManager);
 const importManager = new ImportManager(sceneManager, selectionManager, panel);
 const materialPanel = new MaterialPanel(materialPanelElement);
+const infoPanel = new InfoPanel(infoPanelElement);
 
 materialPanel.update(selectionManager.getSelectionState().selectedMeshes);
 

--- a/src/main.js
+++ b/src/main.js
@@ -14,11 +14,11 @@ const panelElement = /** @type {HTMLElement | null} */ (document.querySelector('
 const toolbarElement = /** @type {HTMLElement | null} */ (document.querySelector('[data-toolbar]'));
 const inspectorElement = /** @type {HTMLElement | null} */ (document.querySelector('[data-inspector]'));
 const materialPanelElement = /** @type {HTMLElement | null} */ (
-  document.querySelector('[data-material-panel]'),
+  document.querySelector('[data-material-panel]')
 );
 const infoPanelElement = /** @type {HTMLElement | null} */ (document.querySelector('[data-info-panel]'));
 const dimensionToggle = /** @type {HTMLInputElement | null} */ (
-  document.querySelector('[data-dimension-toggle]'),
+  document.querySelector('[data-dimension-toggle]')
 );
 
 if (

--- a/src/ui/infoPanel.js
+++ b/src/ui/infoPanel.js
@@ -1,0 +1,601 @@
+import { TooltipController } from './tooltip.js';
+
+/**
+ * @typedef {{ id: string; name: string; subs?: CategoryNode[]; previewUrl?: string }} CategoryNode
+ */
+
+/**
+ * @typedef {{ id: number; name: string; hex: string }} ColorOption
+ */
+
+const INFO_TRANSLATIONS = {
+  en: {
+    tabs: {
+      info: 'Info',
+      mesh: 'Mesh',
+    },
+    language: {
+      label: 'Language',
+    },
+    placement: {
+      label: 'Placement type',
+      help: 'Choose a surface on which your AR object can be placed.',
+      options: {
+        all: 'All',
+        floor: 'Floor',
+        wall: 'Wall',
+        ceiling: 'Ceiling',
+        carpet: 'Carpet',
+      },
+    },
+    destination: {
+      label: 'Destination Url',
+      placeholder: 'https://',
+      help: "The user of the application will go to this address if they click the 'Buy' button.",
+    },
+    brand: {
+      label: 'Brand',
+      placeholder: 'Brand name',
+    },
+    category: {
+      label: 'Category',
+      placeholder: 'Select category',
+      help: 'Select the main catalog category for the object.',
+    },
+    subcategory: {
+      label: 'Subcategory',
+      placeholder: 'Select subcategory',
+      previewLabel: 'Preview',
+    },
+    color: {
+      label: 'Color miniature',
+      help: 'Choose a miniature color that will be displayed in color selection menus.',
+    },
+    visibility: {
+      label: 'Visibility',
+      help: 'Choose where the object will be visible.',
+      options: {
+        visible: 'Visible everywhere',
+        catalogs: 'Only in my catalogs',
+        hidden: 'Hidden everywhere',
+      },
+    },
+    covers: {
+      label: 'Covers',
+      add: 'Add Cover',
+      remove: 'Remove cover',
+    },
+    delete: {
+      label: 'Delete object',
+    },
+    loading: 'Loading…',
+    loadFailed: 'Failed to load',
+    noPreview: 'No preview',
+  },
+  ru: {
+    tabs: {
+      info: 'Инфо',
+      mesh: 'Меши',
+    },
+    language: {
+      label: 'Язык',
+    },
+    placement: {
+      label: 'Тип размещения',
+      help: 'Выберите поверхность, на которой может быть размещён ваш объект AR.',
+      options: {
+        all: 'Все',
+        floor: 'Пол',
+        wall: 'Стена',
+        ceiling: 'Потолок',
+        carpet: 'Ковер',
+      },
+    },
+    destination: {
+      label: 'Целевой URL',
+      placeholder: 'https://',
+      help: 'Пользователь перейдёт по этому адресу, если нажмёт кнопку «Купить».',
+    },
+    brand: {
+      label: 'Бренд',
+      placeholder: 'Название бренда',
+    },
+    category: {
+      label: 'Категория',
+      placeholder: 'Выберите категорию',
+      help: 'Выберите основную категорию каталога для объекта.',
+    },
+    subcategory: {
+      label: 'Подкатегория',
+      placeholder: 'Выберите подкатегорию',
+      previewLabel: 'Превью',
+    },
+    color: {
+      label: 'Цвет миниатюры',
+      help: 'Выберите цвет миниатюры, который будет отображаться в меню выбора цвета.',
+    },
+    visibility: {
+      label: 'Видимость',
+      help: 'Укажите, где объект будет отображаться.',
+      options: {
+        visible: 'Видим везде',
+        catalogs: 'Только в моих каталогах',
+        hidden: 'Скрыт везде',
+      },
+    },
+    covers: {
+      label: 'Обложки',
+      add: 'Добавить обложку',
+      remove: 'Удалить обложку',
+    },
+    delete: {
+      label: 'Удалить объект',
+    },
+    loading: 'Загрузка…',
+    loadFailed: 'Не удалось загрузить',
+    noPreview: 'Нет превью',
+  },
+};
+
+const CATEGORY_API = 'https://api.vizbl.us/obj/GetCats';
+const COLOR_API = 'https://api.vizbl.us/obj/GetColors';
+
+/**
+ * Панель с информационными настройками объекта.
+ */
+export class InfoPanel {
+  /**
+   * @param {HTMLElement} root
+   */
+  constructor(root) {
+    this.root = root;
+    this.languageSelect = /** @type {HTMLSelectElement | null} */ (root.querySelector('[data-info-language]'));
+    this.placementSelect = /** @type {HTMLSelectElement | null} */ (root.querySelector('[data-info-placement]'));
+    this.destinationInput = /** @type {HTMLInputElement | null} */ (root.querySelector('[data-info-destination]'));
+    this.brandInput = /** @type {HTMLInputElement | null} */ (root.querySelector('[data-info-brand]'));
+    this.categorySelect = /** @type {HTMLSelectElement | null} */ (root.querySelector('[data-info-category]'));
+    this.subcategoryGroup = /** @type {HTMLElement | null} */ (root.querySelector('[data-info-subcategory-group]'));
+    this.subcategorySelect = /** @type {HTMLSelectElement | null} */ (root.querySelector('[data-info-subcategory]'));
+    this.categoryPreview = /** @type {HTMLElement | null} */ (root.querySelector('[data-info-category-preview]'));
+    this.categoryPreviewImage = /** @type {HTMLImageElement | null} */ (root.querySelector('[data-info-category-image]'));
+    this.visibilitySelect = /** @type {HTMLSelectElement | null} */ (root.querySelector('[data-info-visibility]'));
+    this.colorGrid = /** @type {HTMLElement | null} */ (root.querySelector('[data-info-color-grid]'));
+    this.coverTarget = /** @type {HTMLElement | null} */ (root.querySelector('[data-info-cover-target]'));
+    this.coverImage = /** @type {HTMLImageElement | null} */ (root.querySelector('[data-info-cover-image]'));
+    this.coverInput = /** @type {HTMLInputElement | null} */ (root.querySelector('[data-info-cover-input]'));
+    this.coverRemove = /** @type {HTMLButtonElement | null} */ (root.querySelector('[data-info-cover-remove]'));
+    this.deleteButton = /** @type {HTMLButtonElement | null} */ (root.querySelector('[data-info-delete]'));
+    this.tooltip = new TooltipController();
+    this.activeLanguage = 'en';
+    /** @type {CategoryNode[] | null} */
+    this.categories = null;
+    /** @type {CategoryNode | null} */
+    this.selectedCategory = null;
+    /** @type {ColorOption[] | null} */
+    this.colors = null;
+    this.selectedColorId = null;
+
+    this.#bindTooltipButtons();
+    this.#bindLanguage();
+    this.#bindCategorySelect();
+    this.#bindCoverControls();
+    this.#applyLanguage();
+    this.#updateSubcategories();
+    this.#loadInitialData();
+  }
+
+  /**
+   * Подключает обработчики к кнопкам подсказок.
+   */
+  #bindTooltipButtons() {
+    const buttons = /** @type {HTMLButtonElement[]} */ (
+      Array.from(this.root.querySelectorAll('[data-tooltip-button]'))
+    );
+    for (const button of buttons) {
+      button.addEventListener('pointerdown', (event) => {
+        event.stopPropagation();
+      });
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const key = button.getAttribute('data-i18n-tooltip');
+        const text = key ? this.#translatePath(key) : '';
+        this.tooltip.toggle(button, text);
+      });
+      button.addEventListener('pointerenter', () => {
+        const key = button.getAttribute('data-i18n-tooltip');
+        if (!key) {
+          return;
+        }
+        this.tooltip.show(button, this.#translatePath(key));
+      });
+      button.addEventListener('pointerleave', () => {
+        this.tooltip.hide(button, false);
+      });
+      button.addEventListener('focus', () => {
+        const key = button.getAttribute('data-i18n-tooltip');
+        if (!key) {
+          return;
+        }
+        this.tooltip.show(button, this.#translatePath(key));
+      });
+      button.addEventListener('blur', () => {
+        this.tooltip.hide(button, true);
+      });
+    }
+  }
+
+  /**
+   * Настраивает переключение языка.
+   */
+  #bindLanguage() {
+    if (!this.languageSelect) {
+      return;
+    }
+    this.languageSelect.addEventListener('change', () => {
+      this.activeLanguage = this.languageSelect?.value || 'en';
+      this.#applyLanguage();
+    });
+  }
+
+  /**
+   * Применяет текстовые переводы к элементам панели.
+   */
+  #applyLanguage() {
+    const translations = INFO_TRANSLATIONS[this.activeLanguage] || INFO_TRANSLATIONS.en;
+    const scope = this.root.closest('[data-panel]') || this.root;
+    const keyElements = /** @type {HTMLElement[]} */ (
+      Array.from(scope.querySelectorAll('[data-i18n-key]'))
+    );
+    for (const element of keyElements) {
+      const key = element.getAttribute('data-i18n-key');
+      if (!key) {
+        continue;
+      }
+      const translation = this.#translatePath(key);
+      if (translation) {
+        element.textContent = translation;
+      }
+    }
+
+    const placeholderElements = /** @type {HTMLElement[]} */ (
+      Array.from(this.root.querySelectorAll('[data-i18n-placeholder]'))
+    );
+    for (const element of placeholderElements) {
+      const key = element.getAttribute('data-i18n-placeholder');
+      if (!key) {
+        continue;
+      }
+      const translation = this.#translatePath(key);
+      if (translation && 'placeholder' in element) {
+        /** @type {HTMLInputElement} */ (element).placeholder = translation;
+      }
+    }
+
+    const tooltipButtons = /** @type {HTMLButtonElement[]} */ (
+      Array.from(this.root.querySelectorAll('[data-i18n-tooltip]'))
+    );
+    for (const button of tooltipButtons) {
+      const key = button.getAttribute('data-i18n-tooltip');
+      if (!key) {
+        continue;
+      }
+      const translation = this.#translatePath(key);
+      if (translation) {
+        button.setAttribute('aria-label', translation);
+      }
+    }
+
+    if (this.coverRemove) {
+      this.coverRemove.setAttribute('aria-label', this.#translatePath('covers.remove') || 'Remove');
+    }
+  }
+
+  /**
+   * Выполняет запросы за категориями и цветами.
+   */
+  async #loadInitialData() {
+    await Promise.all([this.#loadCategories(), this.#loadColors()]);
+  }
+
+  /**
+   * Загружает категории из API.
+   */
+  async #loadCategories() {
+    if (!this.categorySelect) {
+      return;
+    }
+    this.#setCategoryLoading(true);
+    try {
+      const response = await fetch(CATEGORY_API, { mode: 'cors' });
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+      const data = await response.json();
+      if (!data || !Array.isArray(data.cats)) {
+        throw new Error('Unexpected categories payload');
+      }
+      this.categories = data.cats;
+      this.#populateCategories();
+    } catch (error) {
+      console.error('Failed to load categories', error);
+      this.#setCategoryError();
+    } finally {
+      this.#setCategoryLoading(false);
+    }
+  }
+
+  /**
+   * Загружает цвета из API.
+   */
+  async #loadColors() {
+    if (!this.colorGrid) {
+      return;
+    }
+    this.colorGrid.textContent = this.#translatePath('loading') || 'Loading…';
+    try {
+      const response = await fetch(COLOR_API, { mode: 'cors' });
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+      const data = await response.json();
+      if (!data || !Array.isArray(data.colors)) {
+        throw new Error('Unexpected colors payload');
+      }
+      this.colors = data.colors;
+      this.#renderColors();
+    } catch (error) {
+      console.error('Failed to load colors', error);
+      this.colorGrid.textContent = this.#translatePath('loadFailed') || 'Failed to load';
+    }
+  }
+
+  /**
+   * Заполняет основной список категорий.
+   */
+  #populateCategories() {
+    if (!this.categorySelect) {
+      return;
+    }
+    const existing = Array.from(this.categorySelect.querySelectorAll('option'));
+    for (const option of existing) {
+      if (!option.value) {
+        continue;
+      }
+      option.remove();
+    }
+    if (!this.categories) {
+      return;
+    }
+    for (const category of this.categories) {
+      const option = document.createElement('option');
+      option.value = category.id;
+      option.textContent = category.name;
+      this.categorySelect.append(option);
+    }
+  }
+
+  /**
+   * Настраивает обработчики выбора категории.
+   */
+  #bindCategorySelect() {
+    if (!this.categorySelect) {
+      return;
+    }
+    this.categorySelect.addEventListener('change', () => {
+      const value = this.categorySelect?.value || '';
+      if (!value || !this.categories) {
+        this.selectedCategory = null;
+        this.#updateSubcategories();
+        return;
+      }
+      this.selectedCategory = this.categories.find((category) => category.id === value) ?? null;
+      this.#updateSubcategories();
+    });
+
+    if (this.subcategorySelect) {
+      this.subcategorySelect.addEventListener('change', () => {
+        this.#updateCategoryPreview();
+      });
+    }
+  }
+
+  /**
+   * Обновляет состояние подкатегорий в зависимости от выбранной категории.
+   */
+  #updateSubcategories() {
+    if (!this.subcategoryGroup || !this.subcategorySelect) {
+      return;
+    }
+    const subs = this.selectedCategory?.subs ?? null;
+    this.subcategorySelect.innerHTML = '';
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = this.#translatePath('subcategory.placeholder') || 'Select subcategory';
+    this.subcategorySelect.append(placeholder);
+
+    if (!subs || subs.length === 0) {
+      this.subcategoryGroup.classList.add('is-hidden');
+      this.#updateCategoryPreview();
+      return;
+    }
+    this.subcategoryGroup.classList.remove('is-hidden');
+    for (const sub of subs) {
+      const option = document.createElement('option');
+      option.value = sub.id;
+      option.textContent = sub.name;
+      this.subcategorySelect.append(option);
+    }
+    this.#updateCategoryPreview();
+  }
+
+  /**
+   * Обновляет миниатюру выбранной категории или подкатегории.
+   */
+  #updateCategoryPreview() {
+    if (!this.categoryPreview || !this.categoryPreviewImage) {
+      return;
+    }
+    let previewUrl = this.selectedCategory?.previewUrl ?? '';
+    const subId = this.subcategorySelect?.value || '';
+    if (this.selectedCategory?.subs && subId) {
+      const sub = this.selectedCategory.subs.find((item) => item.id === subId);
+      if (sub?.previewUrl) {
+        previewUrl = sub.previewUrl;
+      }
+    }
+    if (previewUrl) {
+      this.categoryPreviewImage.src = previewUrl;
+      this.categoryPreviewImage.alt = this.#translatePath('subcategory.previewLabel') || 'Preview';
+    } else {
+      this.categoryPreviewImage.removeAttribute('src');
+      this.categoryPreviewImage.alt = this.#translatePath('noPreview') || 'No preview';
+    }
+  }
+
+  /**
+   * Отображает доступные цвета миниатюр.
+   */
+  #renderColors() {
+    if (!this.colorGrid) {
+      return;
+    }
+    this.colorGrid.innerHTML = '';
+    if (!this.colors || this.colors.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'info-panel__color-empty';
+      empty.textContent = this.#translatePath('loadFailed') || 'Failed to load';
+      this.colorGrid.append(empty);
+      return;
+    }
+    for (const color of this.colors) {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'info-panel__color-option';
+      button.style.setProperty('--color-value', `#${color.hex}`);
+      button.dataset.colorId = String(color.id);
+      button.title = color.name;
+      button.innerHTML = `<span class="info-panel__color-swatch" aria-hidden="true"></span><span class="info-panel__color-name">${color.name}</span>`;
+      button.addEventListener('click', () => {
+        this.#selectColor(color.id);
+      });
+      this.colorGrid.append(button);
+    }
+  }
+
+  /**
+   * Устанавливает выбранный цвет.
+   * @param {number} colorId
+   */
+  #selectColor(colorId) {
+    this.selectedColorId = colorId;
+    if (!this.colorGrid) {
+      return;
+    }
+    const buttons = /** @type {HTMLButtonElement[]} */ (
+      Array.from(this.colorGrid.querySelectorAll('.info-panel__color-option'))
+    );
+    for (const button of buttons) {
+      button.classList.toggle('is-active', button.dataset.colorId === String(colorId));
+    }
+  }
+
+  /**
+   * Настраивает загрузку обложки.
+   */
+  #bindCoverControls() {
+    if (this.coverInput) {
+      this.coverInput.addEventListener('change', () => {
+        const file = this.coverInput?.files?.[0] ?? null;
+        if (!file) {
+          return;
+        }
+        const reader = new FileReader();
+        reader.addEventListener('load', () => {
+          if (typeof reader.result === 'string') {
+            this.#setCoverPreview(reader.result);
+          }
+        });
+        reader.readAsDataURL(file);
+      });
+    }
+
+    if (this.coverRemove) {
+      this.coverRemove.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        this.coverInput && (this.coverInput.value = '');
+        this.#setCoverPreview(null);
+      });
+    }
+  }
+
+  /**
+   * Устанавливает превью обложки.
+   * @param {string | null} url
+   */
+  #setCoverPreview(url) {
+    if (!this.coverImage || !this.coverTarget) {
+      return;
+    }
+    if (url) {
+      this.coverImage.src = url;
+      this.coverTarget.classList.add('has-image');
+    } else {
+      this.coverImage.removeAttribute('src');
+      this.coverTarget.classList.remove('has-image');
+    }
+  }
+
+  /**
+   * Включает или отключает индикатор загрузки категорий.
+   * @param {boolean} loading
+   */
+  #setCategoryLoading(loading) {
+    if (!this.categorySelect) {
+      return;
+    }
+    this.categorySelect.disabled = loading;
+    if (loading) {
+      this.categorySelect.dataset.loading = 'true';
+    } else {
+      delete this.categorySelect.dataset.loading;
+    }
+  }
+
+  /**
+   * Отображает ошибку загрузки категорий.
+   */
+  #setCategoryError() {
+    if (!this.categorySelect) {
+      return;
+    }
+    const option = document.createElement('option');
+    option.value = '';
+    option.textContent = this.#translatePath('loadFailed') || 'Failed to load';
+    option.disabled = true;
+    option.selected = true;
+    this.categorySelect.append(option);
+  }
+
+  /**
+   * Возвращает перевод по ключу вида `placement.label`.
+   * @param {string} path
+   * @returns {string | null}
+   */
+  #translatePath(path) {
+    const translations = INFO_TRANSLATIONS[this.activeLanguage] || INFO_TRANSLATIONS.en;
+    const segments = path.split('.');
+    let current = /** @type {any} */ (translations);
+    for (const segment of segments) {
+      if (!current || !(segment in current)) {
+        return null;
+      }
+      current = current[segment];
+    }
+    if (typeof current === 'string') {
+      return current;
+    }
+    return null;
+  }
+}

--- a/src/ui/inspector.js
+++ b/src/ui/inspector.js
@@ -10,11 +10,13 @@ export class Inspector {
    * @param {HTMLElement} root
    * @param {import('../core/transformManager.js').TransformManager} transformManager
    * @param {import('../core/selectionManager.js').SelectionManager} selectionManager
+   * @param {import('../core/undoManager.js').UndoManager} undoManager
    */
-  constructor(root, transformManager, selectionManager) {
+  constructor(root, transformManager, selectionManager, undoManager) {
     this.root = root;
     this.transformManager = transformManager;
     this.selectionManager = selectionManager;
+    this.undoManager = undoManager;
     this.inputs = {
       x: /** @type {HTMLInputElement} */ (root.querySelector('[data-axis="x"]')),
       y: /** @type {HTMLInputElement} */ (root.querySelector('[data-axis="y"]')),
@@ -101,6 +103,7 @@ export class Inspector {
     if (!this.activeMesh || this.isSyncing) {
       return;
     }
+    const snapshot = this.undoManager?.captureSnapshot([this.activeMesh]);
     const parse = (value) => {
       const number = Number(value);
       return Number.isFinite(number) ? number : 0;
@@ -122,6 +125,9 @@ export class Inspector {
     this.transformManager.updateAnchorFromSelection(selectedMeshes);
     this.transformManager.refresh();
     this.#syncInputs();
+    if (snapshot) {
+      this.undoManager?.commitSnapshot(snapshot);
+    }
   }
 
   /**
@@ -135,6 +141,7 @@ export class Inspector {
     if (!initial) {
       return;
     }
+    const snapshot = this.undoManager?.captureSnapshot([this.activeMesh]);
     this.activeMesh.position.copy(initial.position);
     this.activeMesh.rotation.copy(initial.rotation);
     this.activeMesh.scale.copy(initial.scale);
@@ -144,6 +151,9 @@ export class Inspector {
     this.transformManager.updateAnchorFromSelection(selectedMeshes);
     this.transformManager.refresh();
     this.#syncInputs();
+    if (snapshot) {
+      this.undoManager?.commitSnapshot(snapshot);
+    }
   }
 
   /**

--- a/src/ui/materialPanel.js
+++ b/src/ui/materialPanel.js
@@ -3,6 +3,8 @@ import {
   DataTexture,
   LinearFilter,
   LinearSRGBColorSpace,
+  NoBlending,
+  NormalBlending,
   RepeatWrapping,
   SRGBColorSpace,
   TextureLoader,
@@ -1172,14 +1174,19 @@ export class MaterialPanel {
       if (material.alphaMap) {
         material.alphaMap = null;
       }
-      material.opacity = this.opacityValue;
-      material.transparent = this.opacityValue < 1;
+      const fullyOpaque = this.opacityValue >= 0.999;
+      material.opacity = fullyOpaque ? 1 : this.opacityValue;
+      material.transparent = !fullyOpaque;
+      material.blending = fullyOpaque ? NoBlending : NormalBlending;
     } else if (this.opacityMode === 'texture') {
-      material.alphaMap = this.opacityTexture ?? null;
+      const texture = this.opacityTexture ?? null;
+      material.alphaMap = texture;
       material.opacity = 1;
-      material.transparent = Boolean(this.opacityTexture);
-      if (material.alphaMap) {
-        material.alphaMap.needsUpdate = true;
+      const hasTexture = Boolean(texture);
+      material.transparent = hasTexture;
+      material.blending = hasTexture ? NormalBlending : NoBlending;
+      if (texture) {
+        texture.needsUpdate = true;
       }
     } else {
       if (material.alphaMap) {
@@ -1187,6 +1194,7 @@ export class MaterialPanel {
       }
       material.opacity = 1;
       material.transparent = true;
+      material.blending = NormalBlending;
     }
     material.needsUpdate = true;
     this.#queueBakedUpdate();

--- a/src/ui/materialPanel.js
+++ b/src/ui/materialPanel.js
@@ -1191,6 +1191,12 @@ export class MaterialPanel {
       }
     };
 
+    const setDepthWrite = (value) => {
+      if (material.depthWrite !== value) {
+        material.depthWrite = value;
+      }
+    };
+
     if (this.opacityMode === 'slider') {
       if (material.alphaMap) {
         material.alphaMap = null;
@@ -1199,6 +1205,7 @@ export class MaterialPanel {
       material.opacity = fullyOpaque ? 1 : this.opacityValue;
       material.transparent = !fullyOpaque;
       material.blending = fullyOpaque ? NoBlending : NormalBlending;
+      setDepthWrite(fullyOpaque);
       clearAlphaMask();
       setAlphaMode(fullyOpaque ? 'OPAQUE' : 'BLEND');
     } else if (this.opacityMode === 'texture') {
@@ -1210,10 +1217,12 @@ export class MaterialPanel {
       if (useMask) {
         material.transparent = false;
         material.blending = NoBlending;
+        setDepthWrite(true);
         setAlphaMode('MASK');
       } else {
         material.transparent = hasTexture;
         material.blending = hasTexture ? NormalBlending : NoBlending;
+        setDepthWrite(!hasTexture);
         clearAlphaMask();
         setAlphaMode(hasTexture ? 'BLEND' : 'OPAQUE');
       }
@@ -1227,6 +1236,7 @@ export class MaterialPanel {
       material.opacity = 1;
       material.transparent = true;
       material.blending = NormalBlending;
+      setDepthWrite(false);
       clearAlphaMask();
       setAlphaMode('BLEND');
     }

--- a/src/ui/materialPanel.js
+++ b/src/ui/materialPanel.js
@@ -162,8 +162,6 @@ export class MaterialPanel {
     this.savedColorTexture = null;
     /** @type {string} */
     this.savedColorPreview = WHITE_PREVIEW;
-    /** @type {boolean} */
-    this.savedColorIsUpload = false;
     /** @type {string} */
     this.savedColorHex = '#ffffff';
 
@@ -208,7 +206,6 @@ export class MaterialPanel {
     this.activeMaterial = material;
     this.savedColorTexture = material.map ?? null;
     this.savedColorPreview = getTexturePreview(material.map) ?? WHITE_PREVIEW;
-    this.savedColorIsUpload = material.map ? Boolean(material.map.userData?.__isUploaded) : false;
     this.colorMode = material.map ? 'texture' : 'color';
     this.#syncModeInputs();
 
@@ -370,7 +367,6 @@ export class MaterialPanel {
       if (map) {
         this.savedColorTexture = map;
         this.savedColorPreview = getTexturePreview(map) ?? WHITE_PREVIEW;
-        this.savedColorIsUpload = Boolean(map.userData?.__isUploaded);
       }
       if (this.activeMaterial.map) {
         this.activeMaterial.map = null;
@@ -386,7 +382,6 @@ export class MaterialPanel {
       if (activeMap) {
         this.savedColorTexture = activeMap;
         this.savedColorPreview = getTexturePreview(activeMap) ?? WHITE_PREVIEW;
-        this.savedColorIsUpload = Boolean(activeMap.userData?.__isUploaded);
       }
       this.#ensureTextureColorNeutral();
     }
@@ -501,20 +496,14 @@ export class MaterialPanel {
       return;
     }
     const map = this.activeMaterial?.map ?? null;
-    let preview = WHITE_PREVIEW;
-    let isUploaded = false;
-    if (map) {
-      preview = map.userData?.__previewUrl ?? getTexturePreview(map) ?? WHITE_PREVIEW;
-      isUploaded = Boolean(map.userData?.__isUploaded);
-    } else if (this.savedColorTexture) {
-      preview = this.savedColorPreview ?? WHITE_PREVIEW;
-      isUploaded = this.savedColorIsUpload;
-    } else {
-      preview = this.savedColorPreview ?? WHITE_PREVIEW;
-    }
-    this.textureImage.src = preview ?? WHITE_PREVIEW;
+    const preview = map
+      ? map.userData?.__previewUrl ?? getTexturePreview(map)
+      : this.savedColorPreview;
+    const resolvedPreview = preview ?? WHITE_PREVIEW;
+    this.textureImage.src = resolvedPreview;
     if (this.textureTarget) {
-      this.textureTarget.classList.toggle('texture-upload--no-preview', isUploaded);
+      const hasPreview = Boolean(resolvedPreview);
+      this.textureTarget.classList.toggle('texture-upload--no-preview', !hasPreview);
     }
   }
 
@@ -529,10 +518,11 @@ export class MaterialPanel {
     const preview = normalMap
       ? normalMap.userData?.__previewUrl ?? getTexturePreview(normalMap)
       : null;
-    this.normalTextureImage.src = preview ?? NEUTRAL_NORMAL_PREVIEW;
+    const resolvedPreview = preview ?? NEUTRAL_NORMAL_PREVIEW;
+    this.normalTextureImage.src = resolvedPreview;
     if (this.normalTextureTarget) {
-      const isUploaded = Boolean(normalMap?.userData?.__isUploaded);
-      this.normalTextureTarget.classList.toggle('texture-upload--no-preview', isUploaded);
+      const hasPreview = Boolean(resolvedPreview);
+      this.normalTextureTarget.classList.toggle('texture-upload--no-preview', !hasPreview);
     }
   }
 
@@ -565,7 +555,6 @@ export class MaterialPanel {
       this.activeMaterial.needsUpdate = true;
       this.savedColorTexture = texture;
       this.savedColorPreview = getTexturePreview(texture) ?? WHITE_PREVIEW;
-      this.savedColorIsUpload = true;
       this.colorMode = 'texture';
       this.#ensureTextureColorNeutral();
       this.#updateColorModeView();
@@ -606,7 +595,6 @@ export class MaterialPanel {
     }
     this.savedColorTexture = null;
     this.savedColorPreview = WHITE_PREVIEW;
-    this.savedColorIsUpload = false;
     this.colorMode = 'color';
     this.#restoreSavedColor();
     this.#updateColorModeView();
@@ -704,7 +692,6 @@ export class MaterialPanel {
     this.activeMaterial = null;
     this.savedColorTexture = null;
     this.savedColorPreview = WHITE_PREVIEW;
-    this.savedColorIsUpload = false;
     this.savedColorHex = '#ffffff';
     this.colorMode = 'color';
     if (this.colorInput) {

--- a/src/ui/materialPanel.js
+++ b/src/ui/materialPanel.js
@@ -1474,10 +1474,32 @@ export class MaterialPanel {
       roughness: roughnessMap ?? null,
     };
 
-    const hasPackedTexture = Boolean(aoMap && metalnessMap && roughnessMap && aoMap === metalnessMap && aoMap === roughnessMap);
-    if (hasPackedTexture) {
-      this.ormPackedTexture = aoMap;
-      const preview = getTexturePreview(aoMap) ?? previousPreviews.ao ?? WHITE_PREVIEW;
+    const packedTexture = (() => {
+      if (
+        aoMap &&
+        metalnessMap &&
+        aoMap === metalnessMap &&
+        (!roughnessMap || roughnessMap === aoMap)
+      ) {
+        return aoMap;
+      }
+      if (aoMap && roughnessMap && aoMap === roughnessMap && !metalnessMap) {
+        return aoMap;
+      }
+      if (metalnessMap && roughnessMap && metalnessMap === roughnessMap && !aoMap) {
+        return metalnessMap;
+      }
+      return null;
+    })();
+
+    if (packedTexture) {
+      this.ormPackedTexture = packedTexture;
+      const preview =
+        getTexturePreview(packedTexture) ??
+        previousPreviews.ao ??
+        previousPreviews.metalness ??
+        previousPreviews.roughness ??
+        WHITE_PREVIEW;
       this.ormPackedPreview = preview || WHITE_PREVIEW;
       for (const channel of ORM_CHANNELS) {
         this.ormChannelState[channel.key].texture = null;

--- a/src/ui/materialPanel.js
+++ b/src/ui/materialPanel.js
@@ -1384,7 +1384,8 @@ export class MaterialPanel {
       }
     };
 
-    this.#applyBaseTextureAlphaUsage(this.opacityMode === 'slider');
+    const ignoreBaseAlpha = this.opacityMode !== 'color-alpha';
+    this.#applyBaseTextureAlphaUsage(ignoreBaseAlpha);
 
     if (this.opacityMode === 'slider') {
       if (material.alphaMap) {
@@ -1559,10 +1560,13 @@ export class MaterialPanel {
     const modeChanged = this.#ensureValidOpacityMode();
     this.#updateOpacityAvailability();
     this.#updateOpacityModeView();
-    if (this.activeMaterial && (modeChanged || this.opacityMode === 'color-alpha')) {
-      this.#applyOpacityState();
-    } else if (this.activeMaterial && this.opacityMode === 'slider') {
-      this.#applyBaseTextureAlphaUsage(true);
+    if (this.activeMaterial) {
+      if (modeChanged || this.opacityMode === 'color-alpha') {
+        this.#applyOpacityState();
+      } else {
+        const ignoreBaseAlpha = this.opacityMode !== 'color-alpha';
+        this.#applyBaseTextureAlphaUsage(ignoreBaseAlpha);
+      }
     }
     this.#queueBakedUpdate();
   }

--- a/src/ui/materialPanel.js
+++ b/src/ui/materialPanel.js
@@ -220,6 +220,7 @@ export class MaterialPanel {
     this.textureLoader = new TextureLoader();
     this.modeInputs = /** @type {HTMLInputElement[]} */ (Array.from(root.querySelectorAll('[data-color-mode]')));
     this.colorPicker = /** @type {HTMLElement | null} */ (root.querySelector('[data-color-picker]'));
+    this.colorPreview = /** @type {HTMLElement | null} */ (root.querySelector('[data-color-preview]'));
     this.colorInput = /** @type {HTMLInputElement | null} */ (root.querySelector('[data-color-input]'));
     this.texturePicker = /** @type {HTMLElement | null} */ (root.querySelector('[data-color-texture]'));
     this.textureTarget = /** @type {HTMLElement | null} */ (root.querySelector('[data-color-texture-target]'));
@@ -247,6 +248,11 @@ export class MaterialPanel {
     this.savedColorPreview = WHITE_PREVIEW;
     /** @type {string} */
     this.savedColorHex = '#ffffff';
+
+    if (this.colorInput) {
+      this.colorInput.value = this.savedColorHex;
+    }
+    this.#refreshColorPreview();
 
     if (this.textureImage) {
       this.textureImage.src = WHITE_PREVIEW;
@@ -304,6 +310,7 @@ export class MaterialPanel {
     if (this.colorInput) {
       this.colorInput.value = this.savedColorHex;
     }
+    this.#refreshColorPreview();
 
     if (this.colorMode === 'texture') {
       this.#ensureTextureColorNeutral();
@@ -520,6 +527,7 @@ export class MaterialPanel {
     if (this.colorInput) {
       this.colorInput.value = this.savedColorHex;
     }
+    this.#refreshColorPreview();
   }
 
   /**
@@ -545,6 +553,7 @@ export class MaterialPanel {
       this.colorInput.value = normalizedWithHash;
     }
     this.savedColorHex = normalizedWithHash;
+    this.#refreshColorPreview();
   }
 
   /**
@@ -566,6 +575,7 @@ export class MaterialPanel {
         this.activeMaterial.userData = this.activeMaterial.userData ?? {};
         this.activeMaterial.userData.__baseColorBackup = this.savedColorHex;
       }
+      this.#refreshColorPreview();
     } catch (error) {
       console.warn('Не удалось применить цвет', error);
     }
@@ -588,6 +598,18 @@ export class MaterialPanel {
       const hasPreview = Boolean(resolvedPreview);
       this.textureTarget.classList.toggle('texture-upload--no-preview', !hasPreview);
     }
+  }
+
+  /**
+   * Обновляет фон превью цвета.
+   */
+  #refreshColorPreview() {
+    if (!this.colorPreview) {
+      return;
+    }
+    const rawValue = this.colorInput?.value || this.savedColorHex || '#ffffff';
+    const normalized = rawValue.startsWith('#') ? rawValue : `#${rawValue}`;
+    this.colorPreview.style.backgroundColor = normalized;
   }
 
   /**
@@ -781,6 +803,7 @@ export class MaterialPanel {
     if (this.colorInput) {
       this.colorInput.value = this.savedColorHex;
     }
+    this.#refreshColorPreview();
     this.#updateColorModeView();
     this.#updateBaseTexturePreview();
     this.#updateNormalPreview();

--- a/src/ui/materialPanel.js
+++ b/src/ui/materialPanel.js
@@ -459,6 +459,18 @@ export class MaterialPanel {
     this.bakedColorImage = /** @type {HTMLImageElement | null} */ (root.querySelector('[data-baked-color-image]'));
     this.bakedNormalImage = /** @type {HTMLImageElement | null} */ (root.querySelector('[data-baked-normal-image]'));
     this.bakedOrmImage = /** @type {HTMLImageElement | null} */ (root.querySelector('[data-baked-orm-image]'));
+    this.sectionHelpButtons = /** @type {HTMLButtonElement[]} */ (
+      Array.from(root.querySelectorAll('[data-section-help]'))
+    );
+    for (const button of this.sectionHelpButtons) {
+      button.addEventListener('pointerdown', (event) => {
+        event.stopPropagation();
+      });
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+      });
+    }
 
     /** @type {Record<OrmChannelKey, { config: typeof ORM_CHANNELS[number]; separate: { target: HTMLElement | null; image: HTMLImageElement | null; input: HTMLInputElement | null; remove: HTMLButtonElement | null; sliderContainer: HTMLElement | null; slider: HTMLInputElement | null; number: HTMLInputElement | null; }; scalar: { container: HTMLElement | null; image: HTMLImageElement | null; slider: HTMLInputElement | null; number: HTMLInputElement | null; }; }>} */
     this.ormChannels = /** @type {any} */ ({});
@@ -622,7 +634,7 @@ export class MaterialPanel {
     this.#updateOpacityAvailability();
     this.#updateOpacityModeView();
     this.#updateOrmModeView();
-    this.#showMessage('Выберите один меш для настройки материала.');
+    this.#showMessage('Select a single mesh to edit its material.');
   }
 
   /**
@@ -632,7 +644,9 @@ export class MaterialPanel {
   update(selection) {
     if (!selection || selection.size !== 1) {
       this.#clearActiveMaterial();
-      this.#showMessage(selection?.size ? 'Выберите только один меш для редактирования.' : 'Выберите один меш для настройки материала.');
+      this.#showMessage(
+        selection?.size ? 'Select only one mesh to edit.' : 'Select a single mesh to edit its material.'
+      );
       return;
     }
 
@@ -640,7 +654,7 @@ export class MaterialPanel {
     const material = this.#resolveMaterial(mesh);
     if (!material || !material.color || !(material.color instanceof Color)) {
       this.#clearActiveMaterial();
-      this.#showMessage('Материал не поддерживается.');
+      this.#showMessage('The selected material is not supported.');
       return;
     }
 

--- a/src/ui/materialPanel.js
+++ b/src/ui/materialPanel.js
@@ -459,7 +459,7 @@ export class MaterialPanel {
     this.bakedNormalImage = /** @type {HTMLImageElement | null} */ (root.querySelector('[data-baked-normal-image]'));
     this.bakedOrmImage = /** @type {HTMLImageElement | null} */ (root.querySelector('[data-baked-orm-image]'));
 
-    /** @type {Record<OrmChannelKey, { config: typeof ORM_CHANNELS[number]; separate: { target: HTMLElement | null; image: HTMLImageElement | null; input: HTMLInputElement | null; remove: HTMLButtonElement | null; sliderContainer: HTMLElement | null; slider: HTMLInputElement | null; number: HTMLInputElement | null; }; scalar: { image: HTMLImageElement | null; slider: HTMLInputElement | null; number: HTMLInputElement | null; }; }>} */
+    /** @type {Record<OrmChannelKey, { config: typeof ORM_CHANNELS[number]; separate: { target: HTMLElement | null; image: HTMLImageElement | null; input: HTMLInputElement | null; remove: HTMLButtonElement | null; sliderContainer: HTMLElement | null; slider: HTMLInputElement | null; number: HTMLInputElement | null; }; scalar: { container: HTMLElement | null; image: HTMLImageElement | null; slider: HTMLInputElement | null; number: HTMLInputElement | null; }; }>} */
     this.ormChannels = /** @type {any} */ ({});
     for (const channel of ORM_CHANNELS) {
       this.ormChannels[channel.key] = {
@@ -474,6 +474,9 @@ export class MaterialPanel {
           number: /** @type {HTMLInputElement | null} */ (root.querySelector(`[data-orm-${channel.key}-number]`)),
         },
         scalar: {
+          container: /** @type {HTMLElement | null} */ (
+            root.querySelector(`[data-orm-scalar-${channel.key}-container]`)
+          ),
           image: /** @type {HTMLImageElement | null} */ (root.querySelector(`[data-orm-scalar-${channel.key}-image]`)),
           slider: /** @type {HTMLInputElement | null} */ (root.querySelector(`[data-orm-scalar-${channel.key}-slider]`)),
           number: /** @type {HTMLInputElement | null} */ (root.querySelector(`[data-orm-scalar-${channel.key}-number]`)),
@@ -1597,11 +1600,15 @@ export class MaterialPanel {
       if (refs.separate.remove) {
         refs.separate.remove.disabled = this.ormMode !== 'separate' || !state.texture;
       }
+      const scalarEnabled = this.ormMode === 'scalar' && channel.key !== 'ao';
       if (refs.scalar.slider) {
-        refs.scalar.slider.disabled = this.ormMode !== 'scalar';
+        refs.scalar.slider.disabled = !scalarEnabled;
       }
       if (refs.scalar.number) {
-        refs.scalar.number.disabled = this.ormMode !== 'scalar';
+        refs.scalar.number.disabled = !scalarEnabled;
+      }
+      if (refs.scalar.container) {
+        refs.scalar.container.classList.toggle('is-disabled', !scalarEnabled);
       }
       this.#syncChannelInputs(channel.key, null);
       this.#updateChannelPreviews(channel.key);

--- a/src/ui/materialPanel.js
+++ b/src/ui/materialPanel.js
@@ -1,0 +1,600 @@
+import {
+  Color,
+  DataTexture,
+  LinearFilter,
+  LinearSRGBColorSpace,
+  RepeatWrapping,
+  SRGBColorSpace,
+  TextureLoader,
+  Vector2,
+} from 'three';
+
+const WHITE_PREVIEW = createSolidColorDataUrl(100, 100, [255, 255, 255, 255]);
+const NEUTRAL_NORMAL_PREVIEW = createSolidColorDataUrl(100, 100, [128, 128, 255, 255]);
+let neutralNormalTexture = null;
+
+/**
+ * Создает dataURL квадратного изображения заданного цвета.
+ * @param {number} width
+ * @param {number} height
+ * @param {[number, number, number, number]} rgba
+ * @returns {string}
+ */
+function createSolidColorDataUrl(width, height, rgba) {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const context = canvas.getContext('2d');
+  if (!context) {
+    return '';
+  }
+  const [r, g, b, a] = rgba;
+  context.fillStyle = `rgba(${r}, ${g}, ${b}, ${a / 255})`;
+  context.fillRect(0, 0, width, height);
+  return canvas.toDataURL('image/png');
+}
+
+/**
+ * Возвращает нейтральную нормал карту (0.5, 0.5, 1.0).
+ * @returns {import('three').Texture}
+ */
+function getNeutralNormalTexture() {
+  if (!neutralNormalTexture) {
+    const size = 2;
+    const data = new Uint8Array(size * size * 4);
+    for (let i = 0; i < size * size; i += 1) {
+      const offset = i * 4;
+      data[offset] = 128;
+      data[offset + 1] = 128;
+      data[offset + 2] = 255;
+      data[offset + 3] = 255;
+    }
+    neutralNormalTexture = new DataTexture(data, size, size);
+    neutralNormalTexture.name = 'NeutralNormalMap';
+    neutralNormalTexture.needsUpdate = true;
+    neutralNormalTexture.colorSpace = LinearSRGBColorSpace;
+    neutralNormalTexture.minFilter = LinearFilter;
+    neutralNormalTexture.magFilter = LinearFilter;
+    neutralNormalTexture.wrapS = RepeatWrapping;
+    neutralNormalTexture.wrapT = RepeatWrapping;
+  }
+  return neutralNormalTexture;
+}
+
+/**
+ * Преобразует данные изображения в dataURL.
+ * @param {ImageBitmap | HTMLCanvasElement | OffscreenCanvas | { data: ArrayLike<number>; width: number; height: number }} image
+ * @returns {string | null}
+ */
+function imageLikeToDataUrl(image) {
+  const width = image.width ?? image.canvas?.width ?? image.videoWidth ?? image.naturalWidth;
+  const height = image.height ?? image.canvas?.height ?? image.videoHeight ?? image.naturalHeight;
+  if (!width || !height) {
+    return null;
+  }
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const context = canvas.getContext('2d');
+  if (!context) {
+    return null;
+  }
+  if ('data' in image && image.data) {
+    const source = image.data instanceof Uint8ClampedArray ? image.data : new Uint8ClampedArray(image.data);
+    const imageData = new ImageData(source, width, height);
+    context.putImageData(imageData, 0, 0);
+  } else {
+    context.drawImage(/** @type {CanvasImageSource} */ (image), 0, 0, width, height);
+  }
+  return canvas.toDataURL('image/png');
+}
+
+/**
+ * Извлекает dataURL из текстуры.
+ * @param {import('three').Texture | null | undefined} texture
+ * @returns {string | null}
+ */
+function getTexturePreview(texture) {
+  if (!texture || !texture.image) {
+    return null;
+  }
+  const image = texture.image;
+  if (typeof image === 'string') {
+    return image;
+  }
+  if (typeof HTMLImageElement !== 'undefined' && image instanceof HTMLImageElement) {
+    return image.currentSrc || image.src || null;
+  }
+  if (typeof HTMLCanvasElement !== 'undefined' && image instanceof HTMLCanvasElement) {
+    return image.toDataURL('image/png');
+  }
+  if (typeof ImageBitmap !== 'undefined' && image instanceof ImageBitmap) {
+    return imageLikeToDataUrl(image);
+  }
+  if ('data' in image && typeof image.data !== 'undefined') {
+    return imageLikeToDataUrl(/** @type {{ data: ArrayLike<number>; width: number; height: number }} */ (image));
+  }
+  if ('toDataURL' in image && typeof image.toDataURL === 'function') {
+    return image.toDataURL('image/png');
+  }
+  if ('src' in image && typeof image.src === 'string') {
+    return image.src;
+  }
+  return null;
+}
+
+/**
+ * Правая панель настроек материала.
+ */
+export class MaterialPanel {
+  /**
+   * @param {HTMLElement} root
+   */
+  constructor(root) {
+    this.root = root;
+    this.textureLoader = new TextureLoader();
+    this.modeInputs = /** @type {HTMLInputElement[]} */ (Array.from(root.querySelectorAll('[data-color-mode]')));
+    this.colorPicker = /** @type {HTMLElement | null} */ (root.querySelector('[data-color-picker]'));
+    this.colorInput = /** @type {HTMLInputElement | null} */ (root.querySelector('[data-color-input]'));
+    this.texturePicker = /** @type {HTMLElement | null} */ (root.querySelector('[data-color-texture]'));
+    this.textureTarget = /** @type {HTMLElement | null} */ (root.querySelector('[data-color-texture-target]'));
+    this.textureImage = /** @type {HTMLImageElement | null} */ (root.querySelector('[data-color-texture-image]'));
+    this.textureInput = /** @type {HTMLInputElement | null} */ (root.querySelector('[data-color-texture-input]'));
+    this.textureRemoveButton = /** @type {HTMLButtonElement | null} */ (root.querySelector('[data-color-texture-remove]'));
+    this.normalTextureTarget = /** @type {HTMLElement | null} */ (root.querySelector('[data-normal-texture-target]'));
+    this.normalTextureImage = /** @type {HTMLImageElement | null} */ (root.querySelector('[data-normal-texture-image]'));
+    this.normalTextureInput = /** @type {HTMLInputElement | null} */ (root.querySelector('[data-normal-texture-input]'));
+    this.normalTextureRemove = /** @type {HTMLButtonElement | null} */ (root.querySelector('[data-normal-texture-remove]'));
+    this.normalStrengthInput = /** @type {HTMLInputElement | null} */ (root.querySelector('[data-normal-strength]'));
+    this.normalStrengthValue = /** @type {HTMLElement | null} */ (root.querySelector('[data-normal-strength-value]'));
+    this.messageElement = /** @type {HTMLElement | null} */ (root.querySelector('[data-material-message]'));
+    this.bodyElement = /** @type {HTMLElement | null} */ (root.querySelector('[data-material-body]'));
+
+    /** @type {'color' | 'texture'} */
+    this.colorMode = 'color';
+    /** @type {import('three').Object3D | null} */
+    this.activeMesh = null;
+    /** @type {(import('three').Material & { color?: Color; map?: import('three').Texture | null; normalMap?: import('three').Texture | null; normalScale?: import('three').Vector2 }) | null} */
+    this.activeMaterial = null;
+    /** @type {import('three').Texture | null} */
+    this.savedColorTexture = null;
+    /** @type {string} */
+    this.savedColorPreview = WHITE_PREVIEW;
+
+    if (this.textureImage) {
+      this.textureImage.src = WHITE_PREVIEW;
+    }
+    if (this.normalTextureImage) {
+      this.normalTextureImage.src = NEUTRAL_NORMAL_PREVIEW;
+    }
+
+    this.#bindEvents();
+    this.#updateColorModeView();
+    this.#showMessage('Выберите один меш для настройки материала.');
+  }
+
+  /**
+   * Синхронизирует панель с текущим выбором.
+   * @param {Set<import('three').Object3D>} selection
+   */
+  update(selection) {
+    if (!selection || selection.size !== 1) {
+      this.#clearActiveMaterial();
+      this.#showMessage(selection?.size ? 'Выберите только один меш для редактирования.' : 'Выберите один меш для настройки материала.');
+      return;
+    }
+
+    const [mesh] = selection;
+    const material = this.#resolveMaterial(mesh);
+    if (!material || !material.color || !(material.color instanceof Color)) {
+      this.#clearActiveMaterial();
+      this.#showMessage('Материал не поддерживается.');
+      return;
+    }
+
+    this.activeMesh = mesh;
+    this.activeMaterial = material;
+    this.savedColorTexture = material.map ?? null;
+    this.savedColorPreview = getTexturePreview(material.map) ?? WHITE_PREVIEW;
+    this.colorMode = material.map ? 'texture' : 'color';
+    this.#syncModeInputs();
+
+    if (this.colorInput) {
+      this.colorInput.value = `#${material.color.getHexString()}`;
+    }
+
+    if (!material.normalScale) {
+      material.normalScale = new Vector2(1, 1);
+    }
+    if (!material.normalMap) {
+      material.normalMap = getNeutralNormalTexture();
+      material.needsUpdate = true;
+    }
+
+    if (this.normalStrengthInput && material.normalScale) {
+      const raw = Number.isFinite(material.normalScale.x) ? material.normalScale.x : 1;
+      const clamped = Math.min(3, Math.max(0, raw));
+      if (raw !== clamped) {
+        material.normalScale.set(clamped, clamped);
+      }
+      this.normalStrengthInput.value = String(clamped);
+    }
+    this.#updateNormalStrengthValue();
+
+    this.#updateColorModeView();
+    this.#updateBaseTexturePreview();
+    this.#updateNormalPreview();
+    this.#showBody();
+  }
+
+  /**
+   * Настраивает обработчики элементов UI.
+   */
+  #bindEvents() {
+    this.modeInputs.forEach((input) => {
+      input.addEventListener('change', () => {
+        if (!input.checked) {
+          return;
+        }
+        const mode = input.value === 'texture' ? 'texture' : 'color';
+        this.#setColorMode(mode);
+      });
+    });
+
+    if (this.colorInput) {
+      this.colorInput.addEventListener('input', () => {
+        this.#applyColorFromInput();
+      });
+    }
+
+    if (this.textureTarget && this.textureInput) {
+      this.textureTarget.addEventListener('click', (event) => {
+        if ((event.target instanceof HTMLElement) && event.target.closest('[data-color-texture-remove]')) {
+          return;
+        }
+        this.textureInput.click();
+      });
+    }
+
+    if (this.textureInput) {
+      this.textureInput.addEventListener('change', async () => {
+        const file = this.textureInput?.files?.[0];
+        if (!file) {
+          return;
+        }
+        await this.#handleBaseTextureFile(file);
+        this.textureInput.value = '';
+      });
+    }
+
+    if (this.textureRemoveButton) {
+      this.textureRemoveButton.addEventListener('click', (event) => {
+        event.stopPropagation();
+        this.#handleRemoveBaseTexture();
+      });
+    }
+
+    if (this.normalTextureTarget && this.normalTextureInput) {
+      this.normalTextureTarget.addEventListener('click', (event) => {
+        if ((event.target instanceof HTMLElement) && event.target.closest('[data-normal-texture-remove]')) {
+          return;
+        }
+        this.normalTextureInput.click();
+      });
+    }
+
+    if (this.normalTextureInput) {
+      this.normalTextureInput.addEventListener('change', async () => {
+        const file = this.normalTextureInput?.files?.[0];
+        if (!file) {
+          return;
+        }
+        await this.#handleNormalTextureFile(file);
+        this.normalTextureInput.value = '';
+      });
+    }
+
+    if (this.normalTextureRemove) {
+      this.normalTextureRemove.addEventListener('click', (event) => {
+        event.stopPropagation();
+        this.#handleRemoveNormalTexture();
+      });
+    }
+
+    if (this.normalStrengthInput) {
+      this.normalStrengthInput.addEventListener('input', () => {
+        this.#applyNormalStrength();
+      });
+    }
+  }
+
+  /**
+   * Возвращает основной материал меша.
+   * @param {import('three').Object3D} mesh
+   */
+  #resolveMaterial(mesh) {
+    const material = /** @type {any} */ (mesh.material);
+    if (!material) {
+      return null;
+    }
+    if (Array.isArray(material)) {
+      return material.find((item) => item && item.isMaterial) ?? null;
+    }
+    if (material.isMaterial) {
+      return material;
+    }
+    return null;
+  }
+
+  /**
+   * Применяет выбранный режим цвета.
+   * @param {'color' | 'texture'} mode
+   */
+  #setColorMode(mode) {
+    if (this.colorMode === mode) {
+      return;
+    }
+    this.colorMode = mode;
+    if (!this.activeMaterial) {
+      this.#updateColorModeView();
+      return;
+    }
+    if (mode === 'color') {
+      if (this.activeMaterial.map) {
+        this.savedColorTexture = this.activeMaterial.map;
+        this.savedColorPreview = getTexturePreview(this.activeMaterial.map) ?? WHITE_PREVIEW;
+      }
+      this.activeMaterial.map = null;
+      this.activeMaterial.needsUpdate = true;
+    } else if (mode === 'texture') {
+      if (!this.activeMaterial.map && this.savedColorTexture) {
+        this.activeMaterial.map = this.savedColorTexture;
+        this.activeMaterial.needsUpdate = true;
+      }
+    }
+    this.#updateColorModeView();
+    this.#updateBaseTexturePreview();
+  }
+
+  /**
+   * Обновляет представление в зависимости от режима.
+   */
+  #updateColorModeView() {
+    this.#syncModeInputs();
+    if (this.colorPicker) {
+      this.colorPicker.classList.toggle('is-hidden', this.colorMode !== 'color');
+    }
+    if (this.texturePicker) {
+      this.texturePicker.classList.toggle('is-hidden', this.colorMode !== 'texture');
+    }
+    if (this.colorInput) {
+      this.colorInput.disabled = this.colorMode !== 'color';
+    }
+  }
+
+  /**
+   * Синхронизирует radio-инпуты с текущим режимом.
+   */
+  #syncModeInputs() {
+    this.modeInputs.forEach((input) => {
+      input.checked = input.value === this.colorMode;
+    });
+  }
+
+  /**
+   * Применяет цвет из color-инпута к материалу.
+   */
+  #applyColorFromInput() {
+    if (!this.activeMaterial || this.colorMode !== 'color' || !this.colorInput) {
+      return;
+    }
+    const value = this.colorInput.value;
+    if (!value) {
+      return;
+    }
+    try {
+      this.activeMaterial.color?.set(value);
+      this.activeMaterial.needsUpdate = true;
+    } catch (error) {
+      console.warn('Не удалось применить цвет', error);
+    }
+  }
+
+  /**
+   * Обновляет превью базовой текстуры.
+   */
+  #updateBaseTexturePreview() {
+    if (!this.textureImage) {
+      return;
+    }
+    const preview = this.activeMaterial?.map ? getTexturePreview(this.activeMaterial.map) : null;
+    this.textureImage.src = preview ?? this.savedColorPreview ?? WHITE_PREVIEW;
+  }
+
+  /**
+   * Обновляет превью нормал-карты.
+   */
+  #updateNormalPreview() {
+    if (!this.normalTextureImage) {
+      return;
+    }
+    const preview = this.activeMaterial?.normalMap ? getTexturePreview(this.activeMaterial.normalMap) : null;
+    this.normalTextureImage.src = preview ?? NEUTRAL_NORMAL_PREVIEW;
+  }
+
+  /**
+   * Обновляет текстовое представление силы нормал-карты.
+   */
+  #updateNormalStrengthValue() {
+    if (!this.normalStrengthInput || !this.normalStrengthValue) {
+      return;
+    }
+    const value = Number.parseFloat(this.normalStrengthInput.value);
+    if (!Number.isFinite(value)) {
+      this.normalStrengthValue.textContent = '0.00';
+      return;
+    }
+    this.normalStrengthValue.textContent = value.toFixed(2);
+  }
+
+  /**
+   * Обрабатывает загрузку новой базовой текстуры.
+   * @param {File} file
+   */
+  async #handleBaseTextureFile(file) {
+    if (!this.activeMaterial) {
+      return;
+    }
+    try {
+      const texture = await this.#loadTexture(file, SRGBColorSpace);
+      this.activeMaterial.map = texture;
+      this.activeMaterial.needsUpdate = true;
+      this.savedColorTexture = texture;
+      this.savedColorPreview = getTexturePreview(texture) ?? WHITE_PREVIEW;
+      if (this.colorMode !== 'texture') {
+        this.colorMode = 'texture';
+        this.#updateColorModeView();
+      }
+      this.#updateBaseTexturePreview();
+    } catch (error) {
+      console.error('Не удалось загрузить текстуру цвета', error);
+    }
+  }
+
+  /**
+   * Обрабатывает загрузку новой нормал-карты.
+   * @param {File} file
+   */
+  async #handleNormalTextureFile(file) {
+    if (!this.activeMaterial) {
+      return;
+    }
+    try {
+      const texture = await this.#loadTexture(file, LinearSRGBColorSpace);
+      this.activeMaterial.normalMap = texture;
+      this.activeMaterial.needsUpdate = true;
+      this.#updateNormalPreview();
+    } catch (error) {
+      console.error('Не удалось загрузить нормал-карту', error);
+    }
+  }
+
+  /**
+   * Удаляет базовую текстуру.
+   */
+  #handleRemoveBaseTexture() {
+    if (!this.activeMaterial) {
+      return;
+    }
+    if (this.activeMaterial.map) {
+      this.activeMaterial.map = null;
+      this.activeMaterial.needsUpdate = true;
+    }
+    this.savedColorTexture = null;
+    this.savedColorPreview = WHITE_PREVIEW;
+    this.#updateBaseTexturePreview();
+  }
+
+  /**
+   * Восстанавливает нейтральную нормал-карту.
+   */
+  #handleRemoveNormalTexture() {
+    if (!this.activeMaterial) {
+      return;
+    }
+    const neutral = getNeutralNormalTexture();
+    this.activeMaterial.normalMap = neutral;
+    if (this.activeMaterial.normalScale) {
+      this.activeMaterial.normalScale.set(1, 1);
+    }
+    if (this.normalStrengthInput) {
+      this.normalStrengthInput.value = '1';
+    }
+    this.activeMaterial.needsUpdate = true;
+    this.#updateNormalStrengthValue();
+    this.#updateNormalPreview();
+  }
+
+  /**
+   * Применяет силу нормал-карты к материалу.
+   */
+  #applyNormalStrength() {
+    if (!this.activeMaterial || !this.normalStrengthInput) {
+      return;
+    }
+    const value = Number.parseFloat(this.normalStrengthInput.value);
+    if (!Number.isFinite(value)) {
+      return;
+    }
+    const clamped = Math.min(3, Math.max(0, value));
+    if (this.activeMaterial.normalScale) {
+      this.activeMaterial.normalScale.set(clamped, clamped);
+      this.activeMaterial.needsUpdate = true;
+    }
+    this.normalStrengthInput.value = String(clamped);
+    this.#updateNormalStrengthValue();
+  }
+
+  /**
+   * Загружает текстуру из файла.
+   * @param {File} file
+   * @param {number} colorSpace
+   * @returns {Promise<import('three').Texture>}
+   */
+  async #loadTexture(file, colorSpace) {
+    const url = URL.createObjectURL(file);
+    try {
+      const texture = await this.textureLoader.loadAsync(url);
+      texture.colorSpace = colorSpace;
+      texture.name = file.name;
+      texture.needsUpdate = true;
+      return texture;
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  }
+
+  /**
+   * Очищает текущий активный материал.
+   */
+  #clearActiveMaterial() {
+    this.activeMesh = null;
+    this.activeMaterial = null;
+    this.savedColorTexture = null;
+    this.savedColorPreview = WHITE_PREVIEW;
+    this.colorMode = 'color';
+    this.#updateColorModeView();
+    this.#updateBaseTexturePreview();
+    this.#updateNormalPreview();
+    if (this.normalStrengthInput) {
+      this.normalStrengthInput.value = '1';
+    }
+    this.#updateNormalStrengthValue();
+  }
+
+  /**
+   * Показывает сообщение и скрывает тело панели.
+   * @param {string} message
+   */
+  #showMessage(message) {
+    if (this.messageElement) {
+      this.messageElement.textContent = message;
+      this.messageElement.classList.remove('is-hidden');
+    }
+    if (this.bodyElement) {
+      this.bodyElement.classList.add('is-hidden');
+    }
+  }
+
+  /**
+   * Отображает содержимое панели и скрывает сообщение.
+   */
+  #showBody() {
+    if (this.messageElement) {
+      this.messageElement.classList.add('is-hidden');
+    }
+    if (this.bodyElement) {
+      this.bodyElement.classList.remove('is-hidden');
+    }
+  }
+}

--- a/src/ui/panel.js
+++ b/src/ui/panel.js
@@ -84,6 +84,7 @@ export class Panel {
     for (const button of this.tabButtons) {
       const isActive = button.getAttribute('data-panel-tab') === sectionName;
       button.classList.toggle('panel__tab--active', isActive);
+      button.setAttribute('aria-pressed', String(isActive));
     }
     for (const [name, section] of this.sections.entries()) {
       if (!name) {

--- a/src/ui/panel.js
+++ b/src/ui/panel.js
@@ -112,10 +112,16 @@ export class Panel {
 
   /**
    * Создаёт DOM-строку для меша.
-   * @param {{ name: string, onClick: (event: MouseEvent) => void, onHide: () => boolean, onDelete: () => void }} config
+   * @param {{
+   *   name: string,
+   *   onClick: (event: MouseEvent) => void,
+   *   onDoubleClick?: (event: MouseEvent) => void,
+   *   onHide: () => boolean,
+   *   onDelete: () => void
+   * }} config
    * @returns {HTMLLIElement}
    */
-  createMeshRow({ name, onClick, onHide, onDelete }) {
+  createMeshRow({ name, onClick, onDoubleClick, onHide, onDelete }) {
     const li = document.createElement('li');
     li.className = 'mesh-row';
 
@@ -142,6 +148,18 @@ export class Panel {
       }
       onClick(event);
     });
+
+    if (onDoubleClick) {
+      li.addEventListener('dblclick', (event) => {
+        if (
+          event.target instanceof HTMLElement &&
+          event.target.closest('.mesh-row__actions')
+        ) {
+          return;
+        }
+        onDoubleClick(event);
+      });
+    }
 
     hideButton.addEventListener('click', (event) => {
       event.stopPropagation();

--- a/src/ui/panel.js
+++ b/src/ui/panel.js
@@ -10,8 +10,12 @@ export class Panel {
     this.importButton = /** @type {HTMLButtonElement} */ (root.querySelector('[data-import-button]'));
     this.fileInput = /** @type {HTMLInputElement} */ (root.querySelector('[data-file-input]'));
     this.list = /** @type {HTMLUListElement} */ (root.querySelector('[data-mesh-list]'));
+    this.selectAllButton = /** @type {HTMLButtonElement} */ (root.querySelector('[data-select-all]'));
     /** @type {(file: File) => void} */
     this.onImportFile = () => {};
+    /** @type {() => void} */
+    this.onSelectAll = () => {};
+    this.meshCount = this.list?.children.length ?? 0;
 
     if (this.importButton) {
       this.importButton.addEventListener('click', () => {
@@ -20,6 +24,13 @@ export class Panel {
           this.fileInput.click();
         }
       });
+    }
+
+    if (this.selectAllButton) {
+      this.selectAllButton.addEventListener('click', () => {
+        this.onSelectAll();
+      });
+      this.#updateSelectAllState();
     }
 
     if (this.fileInput) {
@@ -39,6 +50,14 @@ export class Panel {
    */
   bindImport(handler) {
     this.onImportFile = handler;
+  }
+
+  /**
+   * Привязывает обработчик массового выбора мешей.
+   * @param {() => void} handler
+   */
+  bindSelectAll(handler) {
+    this.onSelectAll = handler;
   }
 
   /**
@@ -89,6 +108,8 @@ export class Panel {
     actions.append(hideButton, deleteButton);
     li.append(label, actions);
     this.list?.append(li);
+    this.meshCount += 1;
+    this.#updateSelectAllState();
     return li;
   }
 
@@ -99,5 +120,22 @@ export class Panel {
   removeMeshRow(uuid) {
     const row = this.list?.querySelector(`[data-uuid="${uuid}"]`);
     row?.remove();
+    if (this.meshCount > 0) {
+      this.meshCount -= 1;
+    }
+    if (this.meshCount < 0) {
+      this.meshCount = 0;
+    }
+    this.#updateSelectAllState();
+  }
+
+  /**
+   * Обновляет доступность кнопки массового выбора.
+   */
+  #updateSelectAllState() {
+    if (!this.selectAllButton) {
+      return;
+    }
+    this.selectAllButton.disabled = this.meshCount === 0;
   }
 }

--- a/src/ui/panel.js
+++ b/src/ui/panel.js
@@ -11,11 +11,24 @@ export class Panel {
     this.fileInput = /** @type {HTMLInputElement} */ (root.querySelector('[data-file-input]'));
     this.list = /** @type {HTMLUListElement} */ (root.querySelector('[data-mesh-list]'));
     this.selectAllButton = /** @type {HTMLButtonElement} */ (root.querySelector('[data-select-all]'));
+    this.tabButtons = /** @type {HTMLButtonElement[]} */ (
+      Array.from(root.querySelectorAll('[data-panel-tab]'))
+    );
+    this.sections = new Map(
+      Array.from(root.querySelectorAll('[data-panel-section]')).map((section) => [
+        section.getAttribute('data-panel-section') || '',
+        section,
+      ]),
+    );
+    const defaultTab = this.tabButtons.find((button) => button.classList.contains('panel__tab--active'));
+    this.activeSection = defaultTab?.getAttribute('data-panel-tab') || 'info';
     /** @type {(file: File) => void} */
     this.onImportFile = () => {};
     /** @type {() => void} */
     this.onSelectAll = () => {};
     this.meshCount = this.list?.children.length ?? 0;
+
+    this.#bindTabs();
 
     if (this.importButton) {
       this.importButton.addEventListener('click', () => {
@@ -41,6 +54,42 @@ export class Panel {
         const files = Array.from(this.fileInput.files);
         files.forEach((file) => this.onImportFile(file));
       });
+    }
+  }
+
+  /**
+   * Настраивает переключение вкладок панели.
+   */
+  #bindTabs() {
+    for (const button of this.tabButtons) {
+      button.addEventListener('click', () => {
+        const target = button.getAttribute('data-panel-tab') || '';
+        if (!target) {
+          return;
+        }
+        this.#setActiveSection(target);
+      });
+    }
+    if (this.activeSection) {
+      this.#setActiveSection(this.activeSection);
+    }
+  }
+
+  /**
+   * Переключает текущую видимую секцию панели.
+   * @param {string} sectionName
+   */
+  #setActiveSection(sectionName) {
+    this.activeSection = sectionName;
+    for (const button of this.tabButtons) {
+      const isActive = button.getAttribute('data-panel-tab') === sectionName;
+      button.classList.toggle('panel__tab--active', isActive);
+    }
+    for (const [name, section] of this.sections.entries()) {
+      if (!name) {
+        continue;
+      }
+      section.classList.toggle('panel__section--active', name === sectionName);
     }
   }
 

--- a/src/ui/tooltip.js
+++ b/src/ui/tooltip.js
@@ -1,0 +1,112 @@
+let tooltipElement = null;
+
+/**
+ * @returns {HTMLDivElement}
+ */
+function ensureTooltipElement() {
+  if (tooltipElement && document.body.contains(tooltipElement)) {
+    return tooltipElement;
+  }
+  const existing = document.querySelector('.material-tooltip');
+  if (existing instanceof HTMLDivElement) {
+    tooltipElement = existing;
+    return tooltipElement;
+  }
+  tooltipElement = document.createElement('div');
+  tooltipElement.className = 'material-tooltip';
+  tooltipElement.setAttribute('role', 'tooltip');
+  tooltipElement.style.left = '-9999px';
+  tooltipElement.style.top = '-9999px';
+  document.body.appendChild(tooltipElement);
+  return tooltipElement;
+}
+
+/**
+ * Контроллер всплывающих подсказок, прикреплённых к кнопкам.
+ */
+export class TooltipController {
+  constructor() {
+    this.tooltip = ensureTooltipElement();
+    /** @type {HTMLElement | null} */
+    this.activeTrigger = null;
+  }
+
+  /**
+   * Показывает подсказку.
+   * @param {HTMLElement} trigger
+   * @param {string} text
+   */
+  show(trigger, text) {
+    this.activeTrigger = trigger;
+    this.tooltip.textContent = text;
+    this.tooltip.classList.add('is-visible');
+    this.#position(trigger);
+  }
+
+  /**
+   * Переключает состояние подсказки для элемента.
+   * @param {HTMLElement} trigger
+   * @param {string} text
+   */
+  toggle(trigger, text) {
+    if (this.activeTrigger === trigger && this.tooltip.classList.contains('is-visible')) {
+      this.hide(trigger, true);
+    } else {
+      this.show(trigger, text);
+    }
+  }
+
+  /**
+   * Скрывает подсказку.
+   * @param {HTMLElement} trigger
+   * @param {boolean} force
+   */
+  hide(trigger, force) {
+    if (!force && document.activeElement === trigger) {
+      return;
+    }
+    if (!force && this.activeTrigger && this.activeTrigger !== trigger) {
+      return;
+    }
+    this.tooltip.classList.remove('is-visible');
+    this.tooltip.style.left = '-9999px';
+    this.tooltip.style.top = '-9999px';
+    if (force || this.activeTrigger === trigger) {
+      this.activeTrigger = null;
+    }
+  }
+
+  /**
+   * Позиционирует подсказку около элемента.
+   * @param {HTMLElement} trigger
+   */
+  #position(trigger) {
+    const rect = trigger.getBoundingClientRect();
+    const margin = 12;
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    // Сначала позиционируем под кнопкой по центру.
+    this.tooltip.style.left = '-9999px';
+    this.tooltip.style.top = '-9999px';
+    const tooltipRect = this.tooltip.getBoundingClientRect();
+    let left = rect.left + rect.width / 2 - tooltipRect.width / 2;
+    let top = rect.bottom + margin;
+
+    if (top + tooltipRect.height + margin > viewportHeight) {
+      top = rect.top - tooltipRect.height - margin;
+    }
+    if (top < margin) {
+      top = margin;
+    }
+    if (left + tooltipRect.width + margin > viewportWidth) {
+      left = viewportWidth - tooltipRect.width - margin;
+    }
+    if (left < margin) {
+      left = margin;
+    }
+
+    this.tooltip.style.left = `${Math.round(left)}px`;
+    this.tooltip.style.top = `${Math.round(top)}px`;
+  }
+}

--- a/style.css
+++ b/style.css
@@ -284,15 +284,31 @@ canvas#scene {
 
 .info-field__select {
   position: relative;
+  display: flex;
+  align-items: center;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(255, 255, 255, 0.92);
+  padding: 2px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.info-field__select:hover {
+  border-color: rgba(59, 130, 246, 0.45);
+  background: rgba(255, 255, 255, 0.96);
 }
 
 .info-field__input--select {
   appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
-  padding-right: 44px;
+  width: 100%;
+  padding: 10px 44px 10px 14px;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: #0f172a;
   cursor: pointer;
-  background-color: rgba(255, 255, 255, 0.9);
 }
 
 .info-field__input--select::-ms-expand {
@@ -309,7 +325,7 @@ canvas#scene {
   position: absolute;
   pointer-events: none;
   top: 50%;
-  right: 18px;
+  right: 16px;
   width: 10px;
   height: 6px;
   transform: translateY(-50%);
@@ -319,16 +335,30 @@ canvas#scene {
   transition: filter 0.2s ease;
 }
 
+.info-field__select:focus-within {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+  background: #ffffff;
+}
+
+.info-field__input--select:focus {
+  outline: none;
+  box-shadow: none;
+}
+
 .info-field__select:focus-within::after {
   filter: brightness(0) saturate(100%) invert(29%) sepia(82%) saturate(3187%) hue-rotate(215deg)
     brightness(92%) contrast(96%);
 }
 
 .info-field__input:focus {
+  outline: none;
+}
+
+.info-field__input:not(.info-field__input--select):focus {
   border-color: #2563eb;
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
   background: #ffffff;
-  outline: none;
 }
 
 .info-field__help {

--- a/style.css
+++ b/style.css
@@ -118,8 +118,8 @@ canvas#scene {
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.panel__tab:hover,
-.panel__tab:focus {
+.panel__tab:hover:not(.panel__tab--active),
+.panel__tab:focus-visible:not(.panel__tab--active) {
   background: rgba(255, 255, 255, 0.95);
   border-color: rgba(148, 163, 184, 0.6);
   box-shadow: 0 8px 18px rgba(15, 23, 42, 0.12);
@@ -128,10 +128,10 @@ canvas#scene {
 }
 
 .panel__tab--active {
-  background: #ffffff;
-  border-color: rgba(59, 130, 246, 0.45);
+  background: rgba(226, 232, 240, 0.9);
+  border-color: rgba(148, 163, 184, 0.55);
   color: #0f172a;
-  box-shadow: 0 10px 24px rgba(59, 130, 246, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
 }
 
 .panel__section {

--- a/style.css
+++ b/style.css
@@ -46,8 +46,41 @@ canvas#scene {
   left: 0;
 }
 
+.panel--left::after,
+.panel--right::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  width: 18px;
+  height: 100%;
+  pointer-events: none;
+  z-index: 9;
+}
+
+.panel--left::after {
+  right: -18px;
+  background: linear-gradient(
+    90deg,
+    rgba(15, 23, 42, 0.16) 0%,
+    rgba(15, 23, 42, 0.08) 35%,
+    rgba(15, 23, 42, 0) 100%
+  );
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.18);
+}
+
 .panel--right {
   right: 0;
+}
+
+.panel--right::after {
+  left: -18px;
+  background: linear-gradient(
+    270deg,
+    rgba(15, 23, 42, 0.16) 0%,
+    rgba(15, 23, 42, 0.08) 35%,
+    rgba(15, 23, 42, 0) 100%
+  );
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.18);
 }
 
 .panel__import {
@@ -450,6 +483,14 @@ canvas#scene {
 
 .texture-upload:hover .texture-upload__label,
 .texture-upload:focus-within .texture-upload__label {
+  opacity: 1;
+}
+
+.texture-upload--no-preview .texture-upload__image {
+  opacity: 0;
+}
+
+.texture-upload--no-preview .texture-upload__label {
   opacity: 1;
 }
 

--- a/style.css
+++ b/style.css
@@ -418,6 +418,7 @@ canvas#scene {
 }
 
 .material-field {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 6px;
@@ -444,6 +445,30 @@ canvas#scene {
   overflow: hidden;
   -webkit-appearance: none;
   appearance: none;
+}
+
+.material-field__hover-label {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 6px 8px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-align: center;
+  color: #ffffff;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0) 0%, rgba(15, 23, 42, 0.75) 100%);
+  border-radius: 0 0 10px 10px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.material-field:hover .material-field__hover-label,
+.material-field:focus-within .material-field__hover-label {
+  opacity: 1;
 }
 
 .material-field__input::-webkit-color-swatch-wrapper {

--- a/style.css
+++ b/style.css
@@ -257,19 +257,6 @@ canvas#scene {
   color: #0f172a;
 }
 
-.info-field__label--with-help {
-  position: relative;
-  display: block;
-  padding-right: 32px;
-}
-
-.info-field__label--with-help .material-section__help-button {
-  position: absolute;
-  top: 50%;
-  right: 0;
-  transform: translateY(-50%);
-}
-
 .info-field__label--split {
   justify-content: space-between;
 }

--- a/style.css
+++ b/style.css
@@ -28,7 +28,6 @@ canvas#scene {
 .panel {
   position: absolute;
   top: 0;
-  left: 0;
   width: 20%;
   min-width: 240px;
   max-width: 360px;
@@ -41,6 +40,14 @@ canvas#scene {
   backdrop-filter: blur(10px);
   box-shadow: 0 0 24px rgba(15, 23, 42, 0.15);
   z-index: 10;
+}
+
+.panel--left {
+  left: 0;
+}
+
+.panel--right {
+  right: 0;
 }
 
 .panel__import {
@@ -178,7 +185,7 @@ canvas#scene {
 .inspector {
   position: absolute;
   top: 16px;
-  right: 16px;
+  right: calc(clamp(240px, 20vw, 360px) + 16px);
   width: 200px;
   display: flex;
   flex-direction: column;
@@ -225,4 +232,250 @@ canvas#scene {
 
 .hidden-input {
   display: none;
+}
+
+.is-hidden {
+  display: none !important;
+}
+
+.material-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  height: 100%;
+}
+
+.material-panel__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.material-panel__message {
+  margin: 0;
+  font-size: 14px;
+  color: #475569;
+  line-height: 1.4;
+}
+
+.material-panel__body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.material-section {
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+  padding: 0 0 8px;
+}
+
+.material-section[open] {
+  padding-bottom: 12px;
+}
+
+.material-section__summary {
+  list-style: none;
+  margin: 0;
+  padding: 12px 16px;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.material-section__summary::-webkit-details-marker {
+  display: none;
+}
+
+.material-section__summary::after {
+  content: '▾';
+  font-size: 12px;
+  color: #475569;
+  transition: transform 0.2s ease;
+}
+
+.material-section[open] .material-section__summary::after {
+  transform: rotate(180deg);
+}
+
+.material-section__content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 0 16px 0;
+}
+
+.material-mode {
+  display: inline-flex;
+  gap: 8px;
+  padding: 4px;
+  border-radius: 8px;
+  background: rgba(148, 163, 184, 0.25);
+}
+
+.material-mode__option {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #1f2937;
+  cursor: pointer;
+  user-select: none;
+}
+
+.material-mode__option input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.material-mode__option input:checked + span,
+.material-mode__option:hover span {
+  background: #2563eb;
+  color: #ffffff;
+}
+
+.material-mode__option span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  border-radius: 6px;
+  padding: 6px 12px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.material-color-picker,
+.material-texture-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.material-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.material-field__label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.material-field__input {
+  width: 56px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  border-radius: 6px;
+  background: #ffffff;
+}
+
+.texture-upload {
+  position: relative;
+  width: 100px;
+  height: 100px;
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  cursor: pointer;
+  background: rgba(248, 250, 252, 0.9);
+}
+
+.texture-upload__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.texture-upload__remove {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.55);
+  color: #ffffff;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.texture-upload__remove:hover,
+.texture-upload__remove:focus {
+  background: rgba(239, 68, 68, 0.85);
+}
+
+.texture-upload__label {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 6px 8px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-align: center;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0) 0%, rgba(15, 23, 42, 0.75) 100%);
+  color: #ffffff;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+}
+
+.texture-upload:hover .texture-upload__label,
+.texture-upload:focus-within .texture-upload__label {
+  opacity: 1;
+}
+
+.material-slider {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.material-slider__label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #475569;
+}
+
+.material-slider__input {
+  width: 100%;
+}
+
+.material-slider__value {
+  min-width: 44px;
+  text-align: right;
+  font-size: 13px;
+  font-weight: 600;
+  color: #1f2937;
 }

--- a/style.css
+++ b/style.css
@@ -270,11 +270,58 @@ canvas#scene {
   transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
+.info-field__input:hover {
+  border-color: rgba(148, 163, 184, 0.6);
+  background: rgba(255, 255, 255, 0.95);
+}
+
 .info-field__input--multiline {
   resize: vertical;
   min-height: 120px;
   font-family: inherit;
   line-height: 1.5;
+}
+
+.info-field__select {
+  position: relative;
+}
+
+.info-field__input--select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  padding-right: 44px;
+  cursor: pointer;
+  background-color: rgba(255, 255, 255, 0.9);
+}
+
+.info-field__input--select::-ms-expand {
+  display: none;
+}
+
+.info-field__input--select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.info-field__select::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: 50%;
+  right: 18px;
+  width: 10px;
+  height: 6px;
+  transform: translateY(-50%);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%23374151' d='M1.41.58 6 5.17 10.59.58 12 2l-6 6-6-6Z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-size: 100% 100%;
+  transition: filter 0.2s ease;
+}
+
+.info-field__select:focus-within::after {
+  filter: brightness(0) saturate(100%) invert(29%) sepia(82%) saturate(3187%) hue-rotate(215deg)
+    brightness(92%) contrast(96%);
 }
 
 .info-field__input:focus {

--- a/style.css
+++ b/style.css
@@ -349,6 +349,13 @@ canvas#scene {
   justify-content: space-between;
 }
 
+.material-section__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
 .material-section__summary::-webkit-details-marker {
   display: none;
 }
@@ -362,6 +369,65 @@ canvas#scene {
 
 .material-section[open] .material-section__summary::after {
   transform: rotate(180deg);
+}
+
+.material-section__help-button {
+  position: relative;
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  border: 1px solid rgba(15, 23, 42, 0.2);
+  background: rgba(255, 255, 255, 0.9);
+  color: #1f2937;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  cursor: help;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.material-section__help-button:hover,
+.material-section__help-button:focus-visible {
+  background: #2563eb;
+  color: #f8fafc;
+  border-color: rgba(37, 99, 235, 0.4);
+}
+
+.material-section__help-button:focus-visible {
+  outline: 2px solid rgba(37, 99, 235, 0.6);
+  outline-offset: 2px;
+}
+
+.material-section__help-button::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: max-content;
+  max-width: 240px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.92);
+  color: #e2e8f0;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.4;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.28);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+  z-index: 4;
+  text-align: left;
+}
+
+.material-section__help-button:hover::after,
+.material-section__help-button:focus-visible::after {
+  opacity: 1;
 }
 
 .material-section__content {

--- a/style.css
+++ b/style.css
@@ -249,6 +249,20 @@ canvas#scene {
   gap: 12px;
 }
 
+.info-field__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.info-field__header .info-field__label {
+  flex: 1;
+}
+
+.info-field__header .material-section__help-button {
+  flex-shrink: 0;
+}
+
 .info-field__label {
   display: flex;
   align-items: center;

--- a/style.css
+++ b/style.css
@@ -232,22 +232,6 @@ canvas#scene {
   gap: 8px;
 }
 
-.info-panel__group--language {
-  padding-bottom: 12px;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
-}
-
-.info-panel__group--split {
-  flex-direction: row;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  gap: 12px;
-}
-
-.info-panel__group--split .info-field {
-  flex: 1;
-}
-
 .info-field {
   display: flex;
   flex-direction: column;
@@ -283,6 +267,13 @@ canvas#scene {
   transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
+.info-field__input--multiline {
+  resize: vertical;
+  min-height: 120px;
+  font-family: inherit;
+  line-height: 1.5;
+}
+
 .info-field__input:focus {
   border-color: #2563eb;
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
@@ -311,86 +302,6 @@ canvas#scene {
   background: rgba(37, 99, 235, 0.12);
   color: #1d4ed8;
   outline: none;
-}
-
-.info-panel__preview {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-  padding: 10px;
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.75);
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
-  flex: none;
-}
-
-.info-panel__preview img {
-  width: 100px;
-  height: 100px;
-  border-radius: 12px;
-  object-fit: cover;
-  background: #f1f5f9;
-}
-
-.info-panel__preview-label {
-  font-size: 12px;
-  font-weight: 600;
-  color: #475569;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-.info-panel__color-grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.info-panel__color-option {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-  width: 80px;
-  padding: 12px 10px;
-  border-radius: 14px;
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  background: rgba(255, 255, 255, 0.8);
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-}
-
-.info-panel__color-option:hover,
-.info-panel__color-option:focus {
-  border-color: #2563eb;
-  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.25);
-  transform: translateY(-1px);
-  outline: none;
-}
-
-.info-panel__color-option.is-active {
-  border-color: #2563eb;
-  box-shadow: 0 10px 26px rgba(37, 99, 235, 0.3);
-}
-
-.info-panel__color-swatch {
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  background: var(--color-value, #ffffff);
-  box-shadow: inset 0 0 0 2px rgba(15, 23, 42, 0.12);
-}
-
-.info-panel__color-name {
-  font-size: 12px;
-  color: #1e293b;
-  text-align: center;
-}
-
-.info-panel__color-empty {
-  font-size: 13px;
-  color: #64748b;
 }
 
 .info-panel__covers {

--- a/style.css
+++ b/style.css
@@ -255,10 +255,6 @@ canvas#scene {
   gap: 8px;
 }
 
-.info-field__header .info-field__label {
-  flex: 1;
-}
-
 .info-field__header .material-section__help-button {
   flex-shrink: 0;
 }

--- a/style.css
+++ b/style.css
@@ -700,9 +700,9 @@ canvas#scene {
   width: 20px;
   height: 20px;
   border-radius: 999px;
-  border: 1px solid rgba(15, 23, 42, 0.2);
-  background: rgba(255, 255, 255, 0.9);
-  color: #1f2937;
+  border: none;
+  background: rgba(148, 163, 184, 0.28);
+  color: #0f172a;
   font-size: 12px;
   font-weight: 600;
   line-height: 1;
@@ -711,18 +711,17 @@ canvas#scene {
   justify-content: center;
   padding: 0;
   cursor: help;
-  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease;
 }
 
 .material-section__help-button:hover,
 .material-section__help-button:focus-visible {
-  background: #2563eb;
+  background: rgba(15, 23, 42, 0.92);
   color: #f8fafc;
-  border-color: rgba(37, 99, 235, 0.4);
 }
 
 .material-section__help-button:focus-visible {
-  outline: 2px solid rgba(37, 99, 235, 0.6);
+  outline: 2px solid rgba(15, 23, 42, 0.5);
   outline-offset: 2px;
 }
 

--- a/style.css
+++ b/style.css
@@ -109,9 +109,9 @@ canvas#scene {
   flex: 1;
   padding: 10px 12px;
   border-radius: 10px;
-  border: 1px solid rgba(148, 163, 184, 0.45);
-  background: rgba(255, 255, 255, 0.75);
-  color: #1e293b;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(248, 250, 252, 0.85);
+  color: #0f172a;
   font-size: 14px;
   font-weight: 600;
   cursor: pointer;
@@ -120,17 +120,18 @@ canvas#scene {
 
 .panel__tab:hover,
 .panel__tab:focus {
-  background: rgba(15, 23, 42, 0.75);
-  border-color: rgba(15, 23, 42, 0.85);
-  color: #f8fafc;
+  background: rgba(255, 255, 255, 0.95);
+  border-color: rgba(148, 163, 184, 0.6);
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.12);
+  color: #0f172a;
   outline: none;
 }
 
 .panel__tab--active {
-  background: #0f172a;
-  border-color: #0f172a;
-  color: #f8fafc;
-  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.45);
+  background: #ffffff;
+  border-color: rgba(59, 130, 246, 0.45);
+  color: #0f172a;
+  box-shadow: 0 10px 24px rgba(59, 130, 246, 0.25);
 }
 
 .panel__section {

--- a/style.css
+++ b/style.css
@@ -120,17 +120,17 @@ canvas#scene {
 
 .panel__tab:hover,
 .panel__tab:focus {
-  background: rgba(59, 130, 246, 0.12);
-  border-color: rgba(59, 130, 246, 0.6);
-  color: #1d4ed8;
+  background: rgba(15, 23, 42, 0.75);
+  border-color: rgba(15, 23, 42, 0.85);
+  color: #f8fafc;
   outline: none;
 }
 
 .panel__tab--active {
-  background: #2563eb;
-  border-color: #2563eb;
-  color: #ffffff;
-  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.35);
+  background: #0f172a;
+  border-color: #0f172a;
+  color: #f8fafc;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.45);
 }
 
 .panel__section {

--- a/style.css
+++ b/style.css
@@ -417,12 +417,16 @@ canvas#scene {
   gap: 8px;
 }
 
+.material-color-picker {
+  align-items: flex-start;
+}
+
 .material-field {
   position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  align-items: flex-start;
+  display: inline-block;
+  width: 100px;
+  height: 100px;
+  cursor: pointer;
 }
 
 .material-field__label {
@@ -434,8 +438,8 @@ canvas#scene {
 }
 
 .material-field__input {
-  width: 100px;
-  height: 100px;
+  inline-size: 100%;
+  block-size: 100%;
   padding: 0;
   border: 1px solid rgba(148, 163, 184, 0.3);
   border-radius: 10px;

--- a/style.css
+++ b/style.css
@@ -128,10 +128,10 @@ canvas#scene {
 }
 
 .panel__tab--active {
-  background: rgba(226, 232, 240, 0.9);
-  border-color: rgba(148, 163, 184, 0.55);
-  color: #0f172a;
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
+  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  border-color: rgba(37, 99, 235, 0.9);
+  color: #ffffff;
+  box-shadow: 0 10px 22px rgba(37, 99, 235, 0.35);
 }
 
 .panel__section {

--- a/style.css
+++ b/style.css
@@ -402,14 +402,11 @@ canvas#scene {
   outline-offset: 2px;
 }
 
-.material-section__help-button::after {
-  content: attr(data-tooltip);
-  position: absolute;
-  top: calc(100% + 8px);
-  left: 50%;
-  transform: translateX(-50%);
-  width: max-content;
-  max-width: 240px;
+.material-tooltip {
+  position: fixed;
+  top: 0;
+  left: 0;
+  max-width: 260px;
   padding: 8px 10px;
   border-radius: 8px;
   background: rgba(15, 23, 42, 0.92);
@@ -418,16 +415,16 @@ canvas#scene {
   font-weight: 500;
   line-height: 1.4;
   box-shadow: 0 8px 24px rgba(15, 23, 42, 0.28);
-  opacity: 0;
   pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
   transition: opacity 0.15s ease;
-  z-index: 4;
-  text-align: left;
+  z-index: 9999;
 }
 
-.material-section__help-button:hover::after,
-.material-section__help-button:focus-visible::after {
+.material-tooltip.is-visible {
   opacity: 1;
+  visibility: visible;
 }
 
 .material-section__content {

--- a/style.css
+++ b/style.css
@@ -147,7 +147,9 @@ canvas#scene {
 
 .panel__section--info {
   overflow-y: auto;
-  padding-right: 4px;
+  padding-right: 12px;
+  margin-right: -8px;
+  scrollbar-gutter: stable both-edges;
 }
 
 .panel__section--info::-webkit-scrollbar {

--- a/style.css
+++ b/style.css
@@ -482,6 +482,28 @@ canvas#scene {
   gap: 16px;
 }
 
+.material-baked {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 16px;
+}
+
+.material-baked__item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.material-baked__label {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #475569;
+}
+
 .material-orm__channel {
   display: flex;
   flex-direction: column;

--- a/style.css
+++ b/style.css
@@ -55,17 +55,28 @@ canvas#scene {
   height: 100%;
   pointer-events: none;
   z-index: 9;
+  background-color: rgba(15, 23, 42, 0.22);
+  filter: drop-shadow(0 10px 30px rgba(15, 23, 42, 0.18));
+  mask-repeat: no-repeat;
+  mask-size: 100% 100%;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-size: 100% 100%;
 }
 
 .panel--left::after {
   right: -18px;
-  background: linear-gradient(
+  mask-image: linear-gradient(
     90deg,
-    rgba(15, 23, 42, 0.16) 0%,
-    rgba(15, 23, 42, 0.08) 35%,
-    rgba(15, 23, 42, 0) 100%
+    rgba(0, 0, 0, 0.75) 0%,
+    rgba(0, 0, 0, 0.45) 40%,
+    rgba(0, 0, 0, 0) 100%
   );
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.18);
+  -webkit-mask-image: linear-gradient(
+    90deg,
+    rgba(0, 0, 0, 0.75) 0%,
+    rgba(0, 0, 0, 0.45) 40%,
+    rgba(0, 0, 0, 0) 100%
+  );
 }
 
 .panel--right {
@@ -74,13 +85,18 @@ canvas#scene {
 
 .panel--right::after {
   left: -18px;
-  background: linear-gradient(
+  mask-image: linear-gradient(
     270deg,
-    rgba(15, 23, 42, 0.16) 0%,
-    rgba(15, 23, 42, 0.08) 35%,
-    rgba(15, 23, 42, 0) 100%
+    rgba(0, 0, 0, 0.75) 0%,
+    rgba(0, 0, 0, 0.45) 40%,
+    rgba(0, 0, 0, 0) 100%
   );
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.18);
+  -webkit-mask-image: linear-gradient(
+    270deg,
+    rgba(0, 0, 0, 0.75) 0%,
+    rgba(0, 0, 0, 0.45) 40%,
+    rgba(0, 0, 0, 0) 100%
+  );
 }
 
 .panel__import {

--- a/style.css
+++ b/style.css
@@ -420,6 +420,51 @@ canvas#scene {
   transition: background 0.2s ease, color 0.2s ease;
 }
 
+.material-mode__option input:disabled {
+  cursor: not-allowed;
+}
+
+.material-mode__option input:disabled + span {
+  background: rgba(148, 163, 184, 0.2);
+  color: rgba(71, 85, 105, 0.6);
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.material-opacity {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  gap: 16px;
+  align-items: center;
+}
+
+.material-opacity--slider .material-slider {
+  width: 100%;
+}
+
+.material-opacity--texture {
+  grid-template-columns: 100px;
+}
+
+.material-opacity--texture .texture-upload {
+  grid-column: 1 / -1;
+}
+
+.material-opacity--color .material-opacity__note {
+  align-self: center;
+}
+
+.material-opacity--color.is-disabled {
+  opacity: 0.5;
+}
+
+.material-opacity__note {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: #475569;
+}
+
 .material-color-picker,
 .material-texture-picker {
   display: flex;

--- a/style.css
+++ b/style.css
@@ -257,6 +257,19 @@ canvas#scene {
   color: #0f172a;
 }
 
+.info-field__label--with-help {
+  position: relative;
+  display: block;
+  padding-right: 32px;
+}
+
+.info-field__label--with-help .material-section__help-button {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  transform: translateY(-50%);
+}
+
 .info-field__label--split {
   justify-content: space-between;
 }

--- a/style.css
+++ b/style.css
@@ -25,6 +25,82 @@ canvas#scene {
   height: 100%;
 }
 
+.viewer-controls {
+  position: absolute;
+  top: 24px;
+  right: 24px;
+  z-index: 12;
+  display: flex;
+  align-items: center;
+  pointer-events: none;
+}
+
+.viewer-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 16px 6px 8px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.78);
+  color: #f8fafc;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  pointer-events: auto;
+  cursor: pointer;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.28);
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.viewer-toggle:hover,
+.viewer-toggle:focus-within {
+  background: rgba(15, 23, 42, 0.9);
+  box-shadow: 0 16px 28px rgba(15, 23, 42, 0.32);
+}
+
+.viewer-toggle__input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.viewer-toggle__switch {
+  position: relative;
+  width: 38px;
+  height: 22px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.45);
+  transition: background 0.25s ease;
+  flex-shrink: 0;
+}
+
+.viewer-toggle__thumb {
+  position: absolute;
+  top: 3px;
+  left: 4px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.24);
+  transition: transform 0.25s ease;
+}
+
+.viewer-toggle__input:checked + .viewer-toggle__switch {
+  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+}
+
+.viewer-toggle__input:checked + .viewer-toggle__switch .viewer-toggle__thumb {
+  transform: translateX(14px);
+}
+
+.viewer-toggle__text {
+  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
 .panel {
   position: absolute;
   top: 0;

--- a/style.css
+++ b/style.css
@@ -273,6 +273,16 @@ canvas#scene {
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
+.inspector__input::-webkit-outer-spin-button,
+.inspector__input::-webkit-inner-spin-button {
+  margin: 0;
+  -webkit-appearance: none;
+}
+
+.inspector__input[type='number'] {
+  -moz-appearance: textfield;
+}
+
 .inspector__input:focus {
   border-color: #2563eb;
   box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
@@ -594,9 +604,30 @@ canvas#scene {
 }
 
 .material-slider__value {
-  min-width: 44px;
-  text-align: right;
+  width: 64px;
+  padding: 6px 8px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  border-radius: 6px;
+  background: #ffffff;
   font-size: 13px;
   font-weight: 600;
   color: #1f2937;
+  text-align: right;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.material-slider__value:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+  outline: none;
+}
+
+.material-slider__value::-webkit-outer-spin-button,
+.material-slider__value::-webkit-inner-spin-button {
+  margin: 0;
+  -webkit-appearance: none;
+}
+
+.material-slider__value[type='number'] {
+  -moz-appearance: textfield;
 }

--- a/style.css
+++ b/style.css
@@ -213,11 +213,14 @@ canvas#scene {
   flex: 1;
   overflow-y: auto;
   margin: 0;
-  padding: 0;
+  padding: 8px;
   list-style: none;
   border-radius: 12px;
-  background: rgba(255, 255, 255, 0.7);
+  background: rgba(255, 255, 255, 0.85);
   box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .info-panel {
@@ -362,17 +365,23 @@ canvas#scene {
   justify-content: space-between;
   gap: 8px;
   padding: 10px 12px;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background: rgba(148, 163, 184, 0.08);
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.mesh-row:last-child {
-  border-bottom: none;
+.mesh-row:hover,
+.mesh-row:focus {
+  background: rgba(148, 163, 184, 0.16);
+  outline: none;
 }
 
 .mesh-row.selected {
-  background: rgba(37, 99, 235, 0.12);
+  background: rgba(37, 99, 235, 0.15);
+  border-color: rgba(37, 99, 235, 0.45);
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.18);
   color: #1d4ed8;
 }
 
@@ -391,6 +400,7 @@ canvas#scene {
 
 .mesh-row__actions {
   display: flex;
+  align-items: center;
   gap: 8px;
 }
 

--- a/style.css
+++ b/style.css
@@ -676,25 +676,57 @@ canvas#scene {
   opacity: 1;
 }
 
-.material-slider {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: 8px;
-  align-items: center;
-}
 
-.material-slider--stacked {
-  grid-template-columns: 1fr;
-  grid-template-rows: repeat(3, auto);
-  gap: 6px;
+.material-control {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  gap: 16px;
   align-items: stretch;
 }
 
+.material-control .texture-upload {
+  width: 100px;
+}
+
+.material-control .material-slider {
+  width: 100%;
+}
+
+.material-control--normal,
+.material-control--channel,
+.material-control--scalar,
+.material-opacity--slider.material-control {
+  align-items: center;
+}
+
+.material-control.is-disabled {
+  opacity: 0.5;
+}
+
+.material-slider {
+  width: 100%;
+}
+
+.material-slider--stacked {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto;
+  gap: 8px 12px;
+  align-items: center;
+}
+
 .material-slider--stacked .material-slider__label {
+  grid-column: 1;
   justify-self: flex-start;
 }
 
+.material-slider--stacked .material-slider__input {
+  grid-column: 1 / -1;
+  width: 100%;
+}
+
 .material-slider--stacked .material-slider__value {
+  grid-column: 2;
   justify-self: flex-end;
 }
 

--- a/style.css
+++ b/style.css
@@ -421,6 +421,7 @@ canvas#scene {
   display: flex;
   flex-direction: column;
   gap: 6px;
+  align-items: flex-start;
 }
 
 .material-field__label {
@@ -432,12 +433,27 @@ canvas#scene {
 }
 
 .material-field__input {
-  width: 56px;
-  height: 32px;
+  width: 100px;
+  height: 100px;
   padding: 0;
-  border: 1px solid rgba(148, 163, 184, 0.6);
-  border-radius: 6px;
-  background: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 10px;
+  background: none;
+  cursor: pointer;
+  box-sizing: border-box;
+  overflow: hidden;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.material-field__input::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.material-field__input::-webkit-color-swatch,
+.material-field__input::-moz-color-swatch {
+  border: none;
+  border-radius: 10px;
 }
 
 .texture-upload {

--- a/style.css
+++ b/style.css
@@ -362,7 +362,8 @@ canvas#scene {
 }
 
 .material-mode {
-  display: inline-flex;
+  display: flex;
+  width: 100%;
   gap: 8px;
   padding: 4px;
   border-radius: 8px;
@@ -372,6 +373,7 @@ canvas#scene {
 .material-mode__option {
   position: relative;
   display: flex;
+  flex: 1 1 0;
   align-items: center;
   justify-content: center;
   border-radius: 6px;

--- a/style.css
+++ b/style.css
@@ -441,17 +441,29 @@ canvas#scene {
   letter-spacing: 0.05em;
 }
 
+.material-field__preview {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: #ffffff;
+  pointer-events: none;
+}
+
 .material-field__input {
+  position: absolute;
+  inset: 0;
   inline-size: 100%;
   block-size: 100%;
   padding: 0;
   border: none;
-  border-radius: 0;
+  border-radius: inherit;
   background: none;
   display: block;
   cursor: pointer;
   box-sizing: border-box;
   overflow: hidden;
+  opacity: 0;
+  z-index: 1;
   -webkit-appearance: none;
   appearance: none;
 }

--- a/style.css
+++ b/style.css
@@ -363,29 +363,6 @@ canvas#scene {
   background: #ffffff;
 }
 
-.info-field__help {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  border-radius: 50%;
-  border: 1px solid rgba(148, 163, 184, 0.6);
-  background: rgba(255, 255, 255, 0.9);
-  color: #2563eb;
-  font-weight: 700;
-  cursor: pointer;
-  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
-}
-
-.info-field__help:hover,
-.info-field__help:focus {
-  border-color: #2563eb;
-  background: rgba(37, 99, 235, 0.12);
-  color: #1d4ed8;
-  outline: none;
-}
-
 .info-panel__covers {
   display: flex;
   flex-wrap: wrap;

--- a/style.css
+++ b/style.css
@@ -423,9 +423,13 @@ canvas#scene {
 
 .material-field {
   position: relative;
-  display: inline-block;
+  display: inline-flex;
   width: 100px;
   height: 100px;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(248, 250, 252, 0.9);
+  overflow: hidden;
   cursor: pointer;
 }
 
@@ -441,9 +445,10 @@ canvas#scene {
   inline-size: 100%;
   block-size: 100%;
   padding: 0;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  border-radius: 10px;
+  border: none;
+  border-radius: 0;
   background: none;
+  display: block;
   cursor: pointer;
   box-sizing: border-box;
   overflow: hidden;
@@ -482,7 +487,7 @@ canvas#scene {
 .material-field__input::-webkit-color-swatch,
 .material-field__input::-moz-color-swatch {
   border: none;
-  border-radius: 10px;
+  border-radius: 0;
 }
 
 .texture-upload {

--- a/style.css
+++ b/style.css
@@ -99,6 +99,66 @@ canvas#scene {
   );
 }
 
+.panel__tabs {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.panel__tab {
+  flex: 1;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(255, 255, 255, 0.75);
+  color: #1e293b;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.panel__tab:hover,
+.panel__tab:focus {
+  background: rgba(59, 130, 246, 0.12);
+  border-color: rgba(59, 130, 246, 0.6);
+  color: #1d4ed8;
+  outline: none;
+}
+
+.panel__tab--active {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #ffffff;
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.35);
+}
+
+.panel__section {
+  display: none;
+  flex-direction: column;
+  gap: 16px;
+  height: 100%;
+  min-height: 0;
+}
+
+.panel__section--active {
+  display: flex;
+}
+
+.panel__section--info {
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.panel__section--info::-webkit-scrollbar {
+  width: 6px;
+}
+
+.panel__section--info::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.5);
+  border-radius: 3px;
+}
+
 .panel__import {
   display: flex;
   flex-direction: column;
@@ -158,6 +218,231 @@ canvas#scene {
   border-radius: 12px;
   background: rgba(255, 255, 255, 0.7);
   box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+}
+
+.info-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.info-panel__group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.info-panel__group--language {
+  padding-bottom: 12px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.info-panel__group--split {
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.info-panel__group--split .info-field {
+  flex: 1;
+}
+
+.info-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+  color: #0f172a;
+}
+
+.info-field--stacked {
+  gap: 12px;
+}
+
+.info-field__label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.info-field__label--split {
+  justify-content: space-between;
+}
+
+.info-field__input {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(255, 255, 255, 0.85);
+  color: #0f172a;
+  font-size: 14px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.info-field__input:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+  background: #ffffff;
+  outline: none;
+}
+
+.info-field__help {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  background: rgba(255, 255, 255, 0.9);
+  color: #2563eb;
+  font-weight: 700;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.info-field__help:hover,
+.info-field__help:focus {
+  border-color: #2563eb;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  outline: none;
+}
+
+.info-panel__preview {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 10px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.75);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+  flex: none;
+}
+
+.info-panel__preview img {
+  width: 100px;
+  height: 100px;
+  border-radius: 12px;
+  object-fit: cover;
+  background: #f1f5f9;
+}
+
+.info-panel__preview-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.info-panel__color-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.info-panel__color-option {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  width: 80px;
+  padding: 12px 10px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(255, 255, 255, 0.8);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.info-panel__color-option:hover,
+.info-panel__color-option:focus {
+  border-color: #2563eb;
+  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.25);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.info-panel__color-option.is-active {
+  border-color: #2563eb;
+  box-shadow: 0 10px 26px rgba(37, 99, 235, 0.3);
+}
+
+.info-panel__color-swatch {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--color-value, #ffffff);
+  box-shadow: inset 0 0 0 2px rgba(15, 23, 42, 0.12);
+}
+
+.info-panel__color-name {
+  font-size: 12px;
+  color: #1e293b;
+  text-align: center;
+}
+
+.info-panel__color-empty {
+  font-size: 13px;
+  color: #64748b;
+}
+
+.info-panel__covers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.texture-upload--cover {
+  width: 120px;
+  height: 160px;
+  align-items: center;
+  justify-content: flex-start;
+  padding-top: 12px;
+  gap: 12px;
+}
+
+.texture-upload--cover .texture-upload__image {
+  width: 100px;
+  height: 100px;
+  border-radius: 12px;
+  object-fit: cover;
+  background: #f1f5f9;
+}
+
+.texture-upload--cover:not(.has-image) .texture-upload__remove {
+  display: none;
+}
+
+.info-panel__group--actions {
+  margin-top: 8px;
+}
+
+.info-panel__delete {
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: 10px;
+  border: 1px solid rgba(239, 68, 68, 0.55);
+  background: rgba(254, 226, 226, 0.65);
+  color: #b91c1c;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.info-panel__delete:hover,
+.info-panel__delete:focus {
+  background: rgba(248, 113, 113, 0.3);
+  border-color: #ef4444;
+  color: #991b1b;
+  outline: none;
 }
 
 .mesh-row {

--- a/style.css
+++ b/style.css
@@ -431,6 +431,27 @@ canvas#scene {
   align-items: flex-start;
 }
 
+.material-orm {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.material-orm__channel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.material-orm__label {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #475569;
+}
+
 .material-field {
   position: relative;
   display: inline-flex;
@@ -576,6 +597,10 @@ canvas#scene {
   opacity: 1;
 }
 
+.texture-upload--readonly {
+  cursor: default;
+}
+
 .texture-upload--no-preview .texture-upload__image {
   opacity: 0;
 }
@@ -589,6 +614,21 @@ canvas#scene {
   grid-template-columns: auto 1fr auto;
   gap: 8px;
   align-items: center;
+}
+
+.material-slider--stacked {
+  grid-template-columns: 1fr;
+  grid-template-rows: repeat(3, auto);
+  gap: 6px;
+  align-items: stretch;
+}
+
+.material-slider--stacked .material-slider__label {
+  justify-self: flex-start;
+}
+
+.material-slider--stacked .material-slider__value {
+  justify-self: flex-end;
 }
 
 .material-slider__label {

--- a/style.css
+++ b/style.css
@@ -123,6 +123,32 @@ canvas#scene {
   background: #1d4ed8;
 }
 
+.panel__select-all-button {
+  width: 100%;
+  padding: 10px 16px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.85);
+  color: #1e293b;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.panel__select-all-button:hover,
+.panel__select-all-button:focus {
+  background: rgba(59, 130, 246, 0.12);
+  border-color: rgba(59, 130, 246, 0.6);
+  color: #1d4ed8;
+  outline: none;
+}
+
+.panel__select-all-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
 .panel__list {
   flex: 1;
   overflow-y: auto;
@@ -235,7 +261,7 @@ canvas#scene {
   position: absolute;
   top: 16px;
   right: calc(clamp(240px, 20vw, 360px) + 16px);
-  width: 200px;
+  width: 232px;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -287,6 +313,32 @@ canvas#scene {
   border-color: #2563eb;
   box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
   outline: none;
+}
+
+.inspector__reset {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  border-radius: 8px;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.inspector__reset:hover,
+.inspector__reset:focus {
+  background: rgba(37, 99, 235, 0.18);
+  border-color: rgba(59, 130, 246, 0.7);
+  color: #1e3a8a;
+  outline: none;
+}
+
+.inspector__reset:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
 .hidden-input {

--- a/style.css
+++ b/style.css
@@ -13,6 +13,10 @@ body {
   background: #ffffff;
 }
 
+:root {
+  --side-panel-width: clamp(240px, 20vw, 360px);
+}
+
 #app {
   position: relative;
   width: 100%;
@@ -27,8 +31,8 @@ canvas#scene {
 
 .viewer-controls {
   position: absolute;
-  top: 24px;
-  right: 24px;
+  left: calc(var(--side-panel-width) + 24px);
+  bottom: 24px;
   z-index: 12;
   display: flex;
   align-items: center;
@@ -104,9 +108,7 @@ canvas#scene {
 .panel {
   position: absolute;
   top: 0;
-  width: 20%;
-  min-width: 240px;
-  max-width: 360px;
+  width: var(--side-panel-width);
   height: 100%;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add a right-side material panel with color mode toggles, texture previews, and normal map controls
- integrate the material panel with selection updates and reposition the transform inspector
- implement MaterialPanel logic for uploading/removing textures, generating fallbacks, and adjusting normal strength

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d2f9815c988322afeca38d4c5d1cb8